### PR TITLE
fix: remove redundant inline tools array from copilot/mcp.json

### DIFF
--- a/src/generators/mcp.ts
+++ b/src/generators/mcp.ts
@@ -13,7 +13,6 @@ interface McpServerConfig {
 interface McpJson {
   version: number;
   servers: Record<string, McpServerConfig>;
-  tools?: ReturnType<typeof getMcpToolsForStack>;
 }
 
 interface GenerateMcpOptions {
@@ -37,7 +36,6 @@ export function generateMcpJson(stack: DetectedStack, outputDir: string, _option
         },
       },
     },
-    tools: allTools,
   };
 
   const copilotDir = path.join(outputDir, '.github', 'copilot');


### PR DESCRIPTION
Closes #1

The MCP server already advertises its tools at runtime via JSON-RPC. Injecting the full inline `tools` array (~190 lines) into `mcp.json` on every bootstrap/refresh run was redundant and required manual cleanup.

**Changes:** `src/generators/mcp.ts`
- Removed `tools?` field from the `McpJson` interface
- Removed `tools: allTools` from the config object written to `mcp.json`

Tool definitions are still written to `.github/ai-os/tools.json` for reference.