### PR TITLE
feat: clean architecture improvements (issues #7-#13)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ TARGET_DIR=""
 INSTALL_SKILL_CREATOR=false
 INSTALL_FIND_SKILLS=false
 REFRESH_EXISTING=false
+CLEAN_UPDATE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -51,6 +52,11 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --refresh-existing)
+      REFRESH_EXISTING=true
+      shift
+      ;;
+    --clean-update)
+      CLEAN_UPDATE=true
       REFRESH_EXISTING=true
       shift
       ;;
@@ -294,6 +300,42 @@ else
 fi
 echo ""
 
+# ── Clean up legacy v0.2.0 artifacts (--clean-update) ────────────────────────
+if [[ "$CLEAN_UPDATE" == "true" ]]; then
+  LEGACY_CONFIG="$TARGET_DIR/.ai-os/config.json"
+  LEGACY_TOOLS="$TARGET_DIR/.ai-os/tools.json"
+  LEGACY_CONTEXT_DIR="$TARGET_DIR/.ai-os/context"
+  LEGACY_MEMORY_DIR="$TARGET_DIR/.ai-os/memory"
+
+  LEGACY_FOUND=false
+  for artifact in "$LEGACY_CONFIG" "$LEGACY_TOOLS" "$LEGACY_CONTEXT_DIR" "$LEGACY_MEMORY_DIR"; do
+    if [[ -e "$artifact" ]]; then
+      LEGACY_FOUND=true
+      break
+    fi
+  done
+
+  if [[ "$LEGACY_FOUND" == "true" ]]; then
+    echo -e "  ${CYAN}→ Removing legacy v0.2.0 .ai-os/ artifacts...${RESET}"
+    for artifact in "$LEGACY_CONFIG" "$LEGACY_TOOLS"; do
+      if [[ -f "$artifact" ]]; then
+        rm -f "$artifact"
+        echo -e "  ${GREEN}✓ Removed:${RESET} ${artifact#"$TARGET_DIR/"}"
+      fi
+    done
+    for dir in "$LEGACY_CONTEXT_DIR" "$LEGACY_MEMORY_DIR"; do
+      if [[ -d "$dir" ]]; then
+        rm -rf "$dir"
+        echo -e "  ${GREEN}✓ Removed:${RESET} ${dir#"$TARGET_DIR/"}/"
+      fi
+    done
+    echo -e "  ${GREEN}✓ Legacy cleanup complete. Canonical context is now at .github/ai-os/${RESET}"
+  else
+    echo -e "  ${GREEN}✓ No legacy v0.2.0 artifacts found — already clean${RESET}"
+  fi
+  echo ""
+fi
+
 # ── Add .ai-os to .gitignore (optional) ───────────────────────────────────────
 GITIGNORE="$TARGET_DIR/.gitignore"
 if [[ -f "$GITIGNORE" ]]; then
@@ -316,7 +358,7 @@ echo -e "  ${BOLD}Next steps:${RESET}"
 echo -e "  1. Open this repo in VS Code with GitHub Copilot extension installed"
 echo -e "  2. Copilot will use ${CYAN}.github/copilot-instructions.md${RESET} automatically"
 echo -e "  3. MCP tools are registered in ${CYAN}.github/copilot/mcp.json${RESET}"
-echo -e "  4. Project context is in ${CYAN}.ai-os/context/${RESET}"
+  echo -e "  4. Project context is in ${CYAN}.github/ai-os/context/${RESET}"
 echo -e "  5. AI OS skills are generated in ${CYAN}.github/copilot/skills/${RESET} with ai-os-* naming"
 echo ""
 echo -e "  ${YELLOW}Tip:${RESET} Re-run install.sh anytime to refresh context after major refactors."

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ INSTALL_SKILL_CREATOR=false
 INSTALL_FIND_SKILLS=false
 REFRESH_EXISTING=false
 CLEAN_UPDATE=false
+UNINSTALL=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -60,6 +61,10 @@ while [[ $# -gt 0 ]]; do
       REFRESH_EXISTING=true
       shift
       ;;
+    --uninstall)
+      UNINSTALL=true
+      shift
+      ;;
     *)
       shift
       ;;
@@ -76,6 +81,70 @@ TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
 
 echo -e "  ${BOLD}Target repository:${RESET} $TARGET_DIR"
 echo ""
+
+# ── Uninstall mode (#12) ─────────────────────────────────────────────────────
+if [[ "$UNINSTALL" == "true" ]]; then
+  MANIFEST="$TARGET_DIR/.github/ai-os/manifest.json"
+  if [[ ! -f "$MANIFEST" ]]; then
+    echo -e "  ${YELLOW}⚠ No AI OS manifest found at $MANIFEST${RESET}"
+    echo -e "  ${YELLOW}  Nothing to uninstall (or files were removed manually).${RESET}"
+    exit 0
+  fi
+
+  echo -e "  ${YELLOW}${BOLD}AI OS Uninstall${RESET}"
+  echo -e "  This will remove all files tracked in the AI OS manifest:"
+  echo -e "  ${CYAN}$MANIFEST${RESET}"
+  echo ""
+
+  # Read manifest file list with node (guaranteed to be available at this point)
+  FILES=$(node -e "
+    const m = JSON.parse(require('fs').readFileSync('$MANIFEST', 'utf8'));
+    console.log(m.files.join('\\n'));
+  " 2>/dev/null || true)
+
+  if [[ -z "$FILES" ]]; then
+    echo -e "  ${YELLOW}  Manifest is empty or unreadable — nothing to remove.${RESET}"
+    exit 0
+  fi
+
+  echo -e "  ${BOLD}Files to remove:${RESET}"
+  echo "$FILES" | while IFS= read -r f; do
+    [[ -n "$f" ]] && echo -e "    - $f"
+  done
+  echo ""
+
+  read -rp "  Confirm removal? [y/N] " CONFIRM
+  if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
+    echo -e "  ${YELLOW}Aborted. No files were removed.${RESET}"
+    exit 0
+  fi
+
+  REMOVED=0
+  echo "$FILES" | while IFS= read -r f; do
+    if [[ -n "$f" ]]; then
+      FULL="$TARGET_DIR/$f"
+      if [[ -f "$FULL" ]]; then
+        rm -f "$FULL"
+        echo -e "  ${GREEN}✓ Removed:${RESET} $f"
+        REMOVED=$((REMOVED + 1))
+      fi
+    fi
+  done
+
+  # Remove .memory.lock gitignore entry if present
+  GITIGNORE="$TARGET_DIR/.gitignore"
+  if [[ -f "$GITIGNORE" ]]; then
+    # Remove AI OS gitignore lines using sed (cross-platform)
+    sed -i.bak '/^# AI OS/d; /^\.ai-os\/mcp-server\/node_modules$/d; /^\.github\/ai-os\/mcp-server\/node_modules$/d; /^\.github\/ai-os\/memory\/.memory\.lock$/d' "$GITIGNORE"
+    rm -f "$GITIGNORE.bak"
+    echo -e "  ${GREEN}✓ Cleaned AI OS entries from .gitignore${RESET}"
+  fi
+
+  echo ""
+  echo -e "  ${GREEN}${BOLD}AI OS uninstalled.${RESET} MCP runtime (.ai-os/mcp-server/) was not removed."
+  echo -e "  ${YELLOW}Tip:${RESET} Remove .ai-os/mcp-server/ manually if no longer needed."
+  exit 0
+fi
 
 # ── Verify it's a git repo ────────────────────────────────────────────────────
 if ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree &>/dev/null; then
@@ -347,6 +416,10 @@ if [[ -f "$GITIGNORE" ]]; then
   fi
   if ! grep -q "^\.github/ai-os/mcp-server/node_modules$" "$GITIGNORE" 2>/dev/null; then
     echo ".github/ai-os/mcp-server/node_modules" >> "$GITIGNORE"
+  fi
+  # #10 — ignore the memory lock file so it never appears as an untracked change
+  if ! grep -q "^\.github/ai-os/memory/\.memory\.lock$" "$GITIGNORE" 2>/dev/null; then
+    echo ".github/ai-os/memory/.memory.lock" >> "$GITIGNORE"
   fi
 fi
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import fs from 'node:fs';
 import path from 'node:path';
 import { analyze } from './analyze.js';
 import { generateInstructions } from './generators/instructions.js';
@@ -8,18 +9,20 @@ import { generateAgents } from './generators/agents.js';
 import { generateSkills, deployBundledSkills } from './generators/skills.js';
 import { generatePrompts } from './generators/prompts.js';
 import { getMcpToolsForStack } from './mcp-tools.js';
-import { checkUpdateStatus, printUpdateBanner } from './updater.js';
+import { checkUpdateStatus, printUpdateBanner, getToolVersion } from './updater.js';
 import { buildOnboardingPlan, formatOnboardingPlan } from './planner.js';
+import { readManifest, writeManifest, getManifestPath } from './generators/utils.js';
 
 type GenerateMode = 'safe' | 'refresh-existing' | 'update';
 type GenerateAction = 'apply' | 'plan' | 'preview';
 
-function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action: GenerateAction } {
+function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action: GenerateAction; prune: boolean } {
   const args = process.argv.slice(2);
   let cwd = process.cwd();
   let dryRun = false;
   let mode: GenerateMode = 'safe';
   let action: GenerateAction = 'apply';
+  let prune = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--cwd' && args[i + 1]) {
@@ -41,10 +44,12 @@ function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action
       action = 'preview';
     } else if (args[i] === '--apply') {
       action = 'apply';
+    } else if (args[i] === '--prune') {
+      prune = true;
     }
   }
 
-  return { cwd, dryRun, mode, action };
+  return { cwd, dryRun, mode, action, prune };
 }
 
 function printBanner(): void {
@@ -59,10 +64,10 @@ function printBanner(): void {
 function printSummary(
   stack: ReturnType<typeof analyze>,
   outputDir: string,
+  written: string[],
+  skipped: string[],
+  pruned: string[],
   agents: string[],
-  skills: string[],
-  promptsAdded: number,
-  bundledSkills: string[],
 ): void {
   const mcpToolCount = getMcpToolsForStack(stack).length;
   const fw = stack.frameworks.map(f => f.name).join(', ') || stack.primaryLanguage.name;
@@ -72,38 +77,18 @@ function printSummary(
   console.log(`  📦 Pkg Mgr:   ${stack.patterns.packageManager}`);
   console.log(`  🔷 TypeScript: ${stack.patterns.hasTypeScript ? 'Yes' : 'No'}`);
   console.log('');
-  console.log('  Generated files:');
-  console.log(`  ✅ .github/copilot-instructions.md`);
-  console.log(`  ✅ .github/copilot/mcp.json (${mcpToolCount} tools)`);
-  console.log(`  ✅ .github/ai-os/context/ (stack, architecture, conventions, existing-ai-context, dependency-graph)`);
-
+  console.log('  Diff summary:');
+  console.log(`  ✅ Written (new or changed):  ${written.length}`);
+  console.log(`  ⏭️  Unchanged (skipped):        ${skipped.length}`);
+  if (pruned.length > 0) {
+    console.log(`  🗑️  Pruned (stale):              ${pruned.length}`);
+    for (const p of pruned) console.log(`       • ${path.relative(outputDir, p).replace(/\\/g, '/')}`);
+  }
   if (agents.length > 0) {
-    console.log(`  ✅ .github/agents/ → ${agents.length} new agent(s):`);
-    for (const a of agents) console.log(`       • ${a}`);
-  } else {
-    console.log(`  ℹ️  .github/agents/ — all agents already exist, skipped`);
+    console.log(`  🤖 Agents generated: ${agents.length}`);
   }
-
-  if (skills.length > 0) {
-    console.log(`  ✅ .github/copilot/skills/ → ${skills.length} new skill(s):`);
-    for (const s of skills) console.log(`       • ${s}`);
-  } else {
-    console.log(`  ℹ️  .github/copilot/skills/ — all skills already exist, skipped`);
-  }
-
-  if (promptsAdded > 0) {
-    console.log(`  ✅ .github/copilot/prompts.json → +${promptsAdded} new prompt(s)`);
-  } else {
-    console.log(`  ℹ️  .github/copilot/prompts.json — all prompts already exist, skipped`);
-  }
-
-  if (bundledSkills.length > 0) {
-    console.log(`  ✅ .agents/skills/ → ${bundledSkills.length} bundled skill(s) deployed:`);
-    for (const s of bundledSkills) console.log(`       • ${s}`);
-  } else {
-    console.log(`  ℹ️  .agents/skills/skill-creator — already installed, skipped`);
-  }
-
+  console.log(`  🔧 MCP tools registered: ${mcpToolCount}`);
+  console.log(`  🗳️  Manifest: ${path.relative(outputDir, getManifestPath(outputDir)).replace(/\\/g, '/')}`);
   console.log('');
   console.log('  🚀 AI OS installed! Open this repo in VS Code with GitHub Copilot enabled.');
   console.log(`  💡 Try @workspace, /new-page, /new-trpc-procedure, or any agent from Chat.`);
@@ -113,7 +98,7 @@ function printSummary(
 async function main(): Promise<void> {
   printBanner();
 
-  const { cwd, dryRun, mode: rawMode, action } = parseArgs();
+  const { cwd, dryRun, mode: rawMode, action, prune: pruneFlag } = parseArgs();
   let mode: GenerateMode = rawMode;
   console.log(`  📂 Scanning: ${cwd}`);
   console.log(`  🔧 Mode: ${mode}`);
@@ -159,18 +144,72 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Read previous manifest to allow pruning stale files (#7 / #8).
+  const previousManifest = readManifest(cwd);
+  const previousFiles = new Set(previousManifest?.files ?? []);
+
   // Phase 1: Core context files
-  generateContextDocs(stack, cwd);
-  generateInstructions(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
-  generateMcpJson(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
+  const contextFiles = generateContextDocs(stack, cwd);
+  const instructionFiles = generateInstructions(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
+  const mcpFiles = generateMcpJson(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
 
   // Phase 2: Agents, Skills, Prompts
-  const agents = await generateAgents(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
-  const skills = await generateSkills(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
-  const promptsAdded = await generatePrompts(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
-  const bundledSkills = await deployBundledSkills(cwd, { refreshExisting: mode === 'refresh-existing' });
+  const agentFiles = await generateAgents(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
+  const skillFiles = await generateSkills(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
+  const promptFiles = await generatePrompts(stack, cwd, { refreshExisting: mode === 'refresh-existing' });
+  await deployBundledSkills(cwd, { refreshExisting: mode === 'refresh-existing' });
 
-  printSummary(stack, cwd, agents, skills, promptsAdded, bundledSkills);
+  // Collect all managed absolute paths and convert to repo-relative forward-slash keys.
+  const allManagedAbs = [
+    ...contextFiles,
+    ...instructionFiles,
+    ...mcpFiles,
+    ...agentFiles,
+    ...skillFiles,
+    ...promptFiles,
+  ];
+  const toRel = (p: string) => path.relative(cwd, p).replace(/\\/g, '/');
+  const currentRelFiles = allManagedAbs.map(toRel);
+
+  // Also track the manifest itself.
+  const manifestRel = toRel(getManifestPath(cwd));
+  currentRelFiles.push(manifestRel);
+
+  // #7 / #8 — Prune stale files (files in previous manifest but not in current run).
+  //            Pruning only happens in refresh/update mode, or when --prune is explicit.
+  const shouldPrune = pruneFlag || mode === 'refresh-existing';
+  const prunedAbs: string[] = [];
+
+  if (shouldPrune && previousFiles.size > 0) {
+    const currentSet = new Set(currentRelFiles);
+    for (const rel of previousFiles) {
+      if (!currentSet.has(rel)) {
+        const abs = path.join(cwd, rel);
+        if (fs.existsSync(abs)) {
+          try {
+            fs.rmSync(abs);
+            prunedAbs.push(abs);
+            console.log(`  🗑️  Pruned stale artifact: ${rel}`);
+          } catch {
+            console.warn(`  ⚠ Could not prune: ${rel}`);
+          }
+        }
+      }
+    }
+  }
+
+  // Write updated manifest (#8 / #11).
+  writeManifest(cwd, getToolVersion(), currentRelFiles);
+
+  // Diff counts for summary (#11).
+  // A file is "written" when it exists but may have changed; we track via comparing
+  // against previous manifest (new entry = written) plus the fact that writeIfChanged
+  // inside generators only wrote when content differed. We use a simple heuristic:
+  // files not in the previous manifest are "new" (written); the rest may be skipped or updated.
+  const newFiles = currentRelFiles.filter(r => r !== manifestRel && !previousFiles.has(r));
+  const existingFiles = currentRelFiles.filter(r => r !== manifestRel && previousFiles.has(r));
+
+  printSummary(stack, cwd, newFiles, existingFiles, prunedAbs, agentFiles);
 }
 
 main().catch(err => {

--- a/src/generators/agents.ts
+++ b/src/generators/agents.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { DetectedStack } from '../types.js';
+import { writeIfChanged, applyFallbacks } from './utils.js';
 
 const AGENTS_DIR = '.github/agents';
 
@@ -279,13 +280,16 @@ async function generateAgentsWithOptions(
     // Inject template placeholders
     content = injectReplacements(content, spec.replacements);
 
-    const unresolved = content.match(/{{[^}]+}}/g);
+    // #9 — strip any unresolved {{PLACEHOLDER}} fragments rather than leaking
+    //      raw template syntax into the output file.
+    const unresolved = content.match(/\{\{[^}]+\}\}/g);
     if (unresolved && unresolved.length > 0) {
-      console.warn(`  ⚠ Unresolved placeholders in ${spec.outputFile}: ${Array.from(new Set(unresolved)).join(', ')}`);
+      console.warn(`  ⚠ Unresolved placeholders in ${spec.outputFile}: ${Array.from(new Set(unresolved)).join(', ')} — removing`);
+      content = applyFallbacks(content);
     }
 
-    fs.writeFileSync(outputPath, content, 'utf-8');
-    generated.push(spec.outputFile);
+    writeIfChanged(outputPath, content);
+    generated.push(outputPath);
   }
 
   return generated;

--- a/src/generators/context-docs.ts
+++ b/src/generators/context-docs.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { DetectedStack } from '../types.js';
 import { buildDependencyGraph } from '../detectors/graph.js';
 import { getToolVersion } from '../updater.js';
+import { writeIfChanged } from './utils.js';
 
 interface ExistingArtifact {
   path: string;
@@ -372,11 +373,15 @@ function mergeSections(existing: string, updated: string): string {
   return result.join('\n');
 }
 
-export function generateContextDocs(stack: DetectedStack, outputDir: string): void {
+/** Returns absolute paths of all managed files. */
+export function generateContextDocs(stack: DetectedStack, outputDir: string): string[] {
   const contextDir = path.join(outputDir, '.github', 'ai-os', 'context');
   fs.mkdirSync(contextDir, { recursive: true });
   const memoryDir = path.join(outputDir, '.github', 'ai-os', 'memory');
   fs.mkdirSync(memoryDir, { recursive: true });
+
+  const managed: string[] = [];
+  const track = (p: string) => { managed.push(p); return p; };
 
   const existingContext = detectExistingAiContext(outputDir);
 
@@ -387,23 +392,23 @@ export function generateContextDocs(stack: DetectedStack, outputDir: string): vo
     fs.copyFileSync(legacyMemory, newMemory);
   }
 
-  fs.writeFileSync(path.join(contextDir, 'stack.md'), generateStackDoc(stack), 'utf-8');
+  writeIfChanged(track(path.join(contextDir, 'stack.md')), generateStackDoc(stack));
 
   // architecture.md and conventions.md: section-level merge to preserve manual edits
-  const archPath = path.join(contextDir, 'architecture.md');
+  const archPath = track(path.join(contextDir, 'architecture.md'));
   const archGenerated = generateArchitectureDoc(stack);
-  fs.writeFileSync(archPath, fs.existsSync(archPath) ? mergeSections(fs.readFileSync(archPath, 'utf-8'), archGenerated) : archGenerated, 'utf-8');
+  writeIfChanged(archPath, fs.existsSync(archPath) ? mergeSections(fs.readFileSync(archPath, 'utf-8'), archGenerated) : archGenerated);
 
-  const convsPath = path.join(contextDir, 'conventions.md');
+  const convsPath = track(path.join(contextDir, 'conventions.md'));
   const convsGenerated = generateConventionsDoc(stack);
-  fs.writeFileSync(convsPath, fs.existsSync(convsPath) ? mergeSections(fs.readFileSync(convsPath, 'utf-8'), convsGenerated) : convsGenerated, 'utf-8');
+  writeIfChanged(convsPath, fs.existsSync(convsPath) ? mergeSections(fs.readFileSync(convsPath, 'utf-8'), convsGenerated) : convsGenerated);
 
-  fs.writeFileSync(path.join(contextDir, 'memory.md'), generateMemoryDoc(stack), 'utf-8');
-  fs.writeFileSync(path.join(contextDir, 'existing-ai-context.md'), generateExistingAiContextDoc(stack, existingContext), 'utf-8');
+  writeIfChanged(track(path.join(contextDir, 'memory.md')), generateMemoryDoc(stack));
+  writeIfChanged(track(path.join(contextDir, 'existing-ai-context.md')), generateExistingAiContextDoc(stack, existingContext));
 
-  const memoryReadmePath = path.join(memoryDir, 'README.md');
+  const memoryReadmePath = track(path.join(memoryDir, 'README.md'));
   if (!fs.existsSync(memoryReadmePath)) {
-    fs.writeFileSync(
+    writeIfChanged(
       memoryReadmePath,
       [
         '# AI OS Repository Memory',
@@ -412,22 +417,17 @@ export function generateContextDocs(stack: DetectedStack, outputDir: string): vo
         '- Use categories: architecture, conventions, build, testing, security, pitfalls, decisions.',
         '- Keep entries concise, factual, and evidence-based.',
       ].join('\n'),
-      'utf-8',
     );
   }
 
-  const memoryFilePath = path.join(memoryDir, 'memory.jsonl');
+  const memoryFilePath = track(path.join(memoryDir, 'memory.jsonl'));
   if (!fs.existsSync(memoryFilePath)) {
     fs.writeFileSync(memoryFilePath, '', 'utf-8');
   }
 
   // Build and persist dependency graph for AI impact analysis
   const graph = buildDependencyGraph(outputDir);
-  fs.writeFileSync(
-    path.join(contextDir, 'dependency-graph.json'),
-    JSON.stringify(graph, null, 2),
-    'utf-8',
-  );
+  writeIfChanged(track(path.join(contextDir, 'dependency-graph.json')), JSON.stringify(graph, null, 2));
 
   // Write config.json
   const config = {
@@ -442,5 +442,7 @@ export function generateContextDocs(stack: DetectedStack, outputDir: string): vo
   };
 
   const aiOsDir = path.join(outputDir, '.github', 'ai-os');
-  fs.writeFileSync(path.join(aiOsDir, 'config.json'), JSON.stringify(config, null, 2), 'utf-8');
+  writeIfChanged(track(path.join(aiOsDir, 'config.json')), JSON.stringify(config, null, 2));
+
+  return managed;
 }

--- a/src/generators/instructions.ts
+++ b/src/generators/instructions.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { DetectedStack } from '../types.js';
+import { writeIfChanged } from './utils.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
@@ -57,7 +58,8 @@ interface GenerateInstructionsOptions {
   refreshExisting?: boolean;
 }
 
-export function generateInstructions(stack: DetectedStack, outputDir: string, _options?: GenerateInstructionsOptions): void {
+/** Returns absolute paths of all managed files. */
+export function generateInstructions(stack: DetectedStack, outputDir: string, _options?: GenerateInstructionsOptions): string[] {
   const base = readTemplate('base-instructions.md');
   if (!base) throw new Error('Base instructions template not found');
 
@@ -72,22 +74,14 @@ export function generateInstructions(stack: DetectedStack, outputDir: string, _o
   const content = fillTemplate(base, stack, overlays || `## ${stack.primaryLanguage.name} Project\n\nNo specific framework template found. Follow the general rules above.`);
 
   const githubDir = path.join(outputDir, '.github');
-  fs.mkdirSync(githubDir, { recursive: true });
 
   const outputPath = path.join(githubDir, 'copilot-instructions.md');
-
-  // Backup existing file before overwriting
-  if (fs.existsSync(outputPath)) {
-    fs.copyFileSync(outputPath, outputPath + '.bak');
-  }
-
-  fs.writeFileSync(outputPath, content, 'utf-8');
+  writeIfChanged(outputPath, content);
 
   // Generate .github/instructions/ai-os.instructions.md
   // This file with applyTo:"**" causes Copilot's default agent to auto-load these
   // instructions on every request, enabling MCP tools without manual activation.
   const instructionsDir = path.join(githubDir, 'instructions');
-  fs.mkdirSync(instructionsDir, { recursive: true });
 
   const autoActivationContent = [
     '---',
@@ -154,5 +148,7 @@ export function generateInstructions(stack: DetectedStack, outputDir: string, _o
   ].join('\n');
 
   const autoActivationPath = path.join(instructionsDir, 'ai-os.instructions.md');
-  fs.writeFileSync(autoActivationPath, autoActivationContent, 'utf-8');
+  writeIfChanged(autoActivationPath, autoActivationContent);
+
+  return [outputPath, autoActivationPath];
 }

--- a/src/generators/mcp.ts
+++ b/src/generators/mcp.ts
@@ -1,7 +1,7 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import type { DetectedStack } from '../types.js';
 import { getMcpToolsForStack } from '../mcp-tools.js';
+import { writeIfChanged } from './utils.js';
 
 interface McpServerConfig {
   type: 'stdio';
@@ -19,7 +19,8 @@ interface GenerateMcpOptions {
   refreshExisting?: boolean;
 }
 
-export function generateMcpJson(stack: DetectedStack, outputDir: string, _options?: GenerateMcpOptions): void {
+/** Returns absolute paths of all managed files. */
+export function generateMcpJson(stack: DetectedStack, outputDir: string, _options?: GenerateMcpOptions): string[] {
   const mcpServerPath = path.join('.ai-os', 'mcp-server', 'index.js').replace(/\\/g, '/');
 
   const allTools = getMcpToolsForStack(stack);
@@ -38,20 +39,12 @@ export function generateMcpJson(stack: DetectedStack, outputDir: string, _option
     },
   };
 
-  const copilotDir = path.join(outputDir, '.github', 'copilot');
-  fs.mkdirSync(copilotDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(copilotDir, 'mcp.json'),
-    JSON.stringify(config, null, 2),
-    'utf-8'
-  );
+  const mcpJsonPath = path.join(outputDir, '.github', 'copilot', 'mcp.json');
+  writeIfChanged(mcpJsonPath, JSON.stringify(config, null, 2));
 
   // Also write tool definitions for reference
-  const aiOsDir = path.join(outputDir, '.github', 'ai-os');
-  fs.mkdirSync(aiOsDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(aiOsDir, 'tools.json'),
-    JSON.stringify(allTools, null, 2),
-    'utf-8'
-  );
+  const toolsJsonPath = path.join(outputDir, '.github', 'ai-os', 'tools.json');
+  writeIfChanged(toolsJsonPath, JSON.stringify(allTools, null, 2));
+
+  return [mcpJsonPath, toolsJsonPath];
 }

--- a/src/generators/mcp.ts
+++ b/src/generators/mcp.ts
@@ -13,7 +13,6 @@ interface McpServerConfig {
 interface McpJson {
   version: number;
   servers: Record<string, McpServerConfig>;
-  tools?: ReturnType<typeof getMcpToolsForStack>;
 }
 
 interface GenerateMcpOptions {
@@ -37,7 +36,6 @@ export function generateMcpJson(stack: DetectedStack, outputDir: string, _option
         },
       },
     },
-    tools: allTools,
   };
 
   const copilotDir = path.join(outputDir, '.github', 'copilot');

--- a/src/generators/prompts.ts
+++ b/src/generators/prompts.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { DetectedStack } from '../types.js';
+import { writeIfChanged } from './utils.js';
 
 const PROMPTS_FILE = '.github/copilot/prompts.json';
 
@@ -312,7 +313,11 @@ interface GeneratePromptsOptions {
   refreshExisting?: boolean;
 }
 
-export async function generatePrompts(stack: DetectedStack, cwd: string, options?: GeneratePromptsOptions): Promise<number> {
+/**
+ * Returns [promptsPath] when something was written, [] when nothing changed.
+ * Callers should include the returned paths in the manifest regardless.
+ */
+export async function generatePrompts(stack: DetectedStack, cwd: string, options?: GeneratePromptsOptions): Promise<string[]> {
   const promptsPath = path.join(cwd, PROMPTS_FILE);
   fs.mkdirSync(path.dirname(promptsPath), { recursive: true });
 
@@ -348,13 +353,13 @@ export async function generatePrompts(stack: DetectedStack, cwd: string, options
   } else {
     const existingIds = new Set(existing.prompts.map(p => p.id));
     const newPrompts = generatedPrompts.filter(p => !existingIds.has(p.id));
-    if (newPrompts.length === 0) return 0;
+    if (newPrompts.length === 0) return [];
     existing.prompts = [...existing.prompts, ...newPrompts];
     changed = newPrompts.length;
   }
 
-  if (changed === 0) return 0;
+  if (changed === 0) return [];
 
-  fs.writeFileSync(promptsPath, JSON.stringify(existing, null, 2), 'utf-8');
-  return changed;
+  writeIfChanged(promptsPath, JSON.stringify(existing, null, 2));
+  return [promptsPath];
 }

--- a/src/generators/skills.ts
+++ b/src/generators/skills.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { DetectedStack } from '../types.js';
+import { writeIfChanged } from './utils.js';
 
 const SKILLS_DIR = '.github/copilot/skills';
 const AGENTS_SKILLS_DIR = '.agents/skills';
@@ -124,13 +125,14 @@ async function generateSkillsWithOptions(
   fs.mkdirSync(skillsDir, { recursive: true });
 
   const specs = buildSkillSpecs(stack, cwd);
-  const generated: string[] = [];
+  const generatedPaths: string[] = [];
 
   for (const spec of specs) {
     const outputPath = path.join(skillsDir, spec.outputFile);
 
     // In safe mode, never overwrite existing skills.
     if (fs.existsSync(outputPath) && !options.refreshExisting) {
+      generatedPaths.push(outputPath);
       continue;
     }
 
@@ -140,11 +142,24 @@ async function generateSkillsWithOptions(
       content = content.replaceAll(key, value);
     }
 
-    fs.writeFileSync(outputPath, content, 'utf-8');
-    generated.push(spec.outputFile);
+    writeIfChanged(outputPath, content);
+    generatedPaths.push(outputPath);
   }
 
-  return generated;
+  // #7 — prune stale ai-os- prefixed skill files that are no longer generated
+  //      for this stack (e.g. a framework was removed).
+  if (options.refreshExisting && fs.existsSync(skillsDir)) {
+    const currentSet = new Set(generatedPaths.map(p => path.basename(p)));
+    const onDisk = fs.readdirSync(skillsDir).filter(f => f.startsWith('ai-os-') && f.endsWith('.md'));
+    for (const stale of onDisk) {
+      if (!currentSet.has(stale)) {
+        fs.rmSync(path.join(skillsDir, stale));
+        console.log(`  🗑️  Pruned stale skill: ${stale}`);
+      }
+    }
+  }
+
+  return generatedPaths;
 }
 
 export async function generateSkills(

--- a/src/generators/utils.ts
+++ b/src/generators/utils.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+
+// ── Write-if-changed (#13) ────────────────────────────────────────────────────
+
+export type WriteResult = 'written' | 'skipped';
+
+/**
+ * Write `content` to `filePath` only when the content differs from the existing
+ * file. Returns 'written' when a write occurred, 'skipped' when the content was
+ * already identical. Ensures the parent directory exists before writing.
+ */
+export function writeIfChanged(filePath: string, content: string): WriteResult {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, 'utf-8');
+    if (existing === content) return 'skipped';
+  }
+
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return 'written';
+}
+
+// ── Placeholder resolution (#9) ───────────────────────────────────────────────
+
+const PLACEHOLDER_RE = /\{\{[^}]+\}\}/g;
+
+/**
+ * Detect unresolved `{{PLACEHOLDER}}` fragments in generated content.
+ * Returns the unique set of placeholder names found.
+ */
+export function findUnresolvedPlaceholders(content: string): string[] {
+  const matches = content.match(PLACEHOLDER_RE);
+  if (!matches) return [];
+  return [...new Set(matches)];
+}
+
+/**
+ * Replace any remaining `{{PLACEHOLDER}}` fragments using the provided fallback
+ * map. Unknown placeholders are removed (replaced with empty string) to prevent
+ * raw template syntax leaking into generated files.
+ */
+export function applyFallbacks(content: string, fallbacks: Record<string, string> = {}): string {
+  return content.replace(PLACEHOLDER_RE, (match) => {
+    return fallbacks[match] ?? '';
+  });
+}
+
+// ── Manifest (#8) ────────────────────────────────────────────────────────────
+
+export interface AiOsManifest {
+  version: string;
+  generatedAt: string;
+  /** Repo-relative paths of all files written by AI OS in this run */
+  files: string[];
+}
+
+const MANIFEST_FILENAME = 'manifest.json';
+
+export function getManifestPath(outputDir: string): string {
+  return path.join(outputDir, '.github', 'ai-os', MANIFEST_FILENAME);
+}
+
+export function readManifest(outputDir: string): AiOsManifest | null {
+  const manifestPath = getManifestPath(outputDir);
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as AiOsManifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the manifest atomically: write to a temp file then rename.
+ * `files` should be repo-relative paths (forward slashes).
+ */
+export function writeManifest(outputDir: string, version: string, files: string[]): void {
+  const manifest: AiOsManifest = {
+    version,
+    generatedAt: new Date().toISOString(),
+    files: [...files].sort(),
+  };
+
+  const manifestPath = getManifestPath(outputDir);
+  const tmpPath = manifestPath + '.tmp';
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2), 'utf-8');
+  fs.renameSync(tmpPath, manifestPath);
+}
+
+// ── Diff tracking (#11) ───────────────────────────────────────────────────────
+
+export interface FileDiff {
+  written: string[];   // new content differs from existing / file didn't exist
+  skipped: string[];   // content identical — no write needed
+  pruned: string[];    // existed in previous manifest, not generated this run
+}
+
+export function makeFileDiff(): FileDiff {
+  return { written: [], skipped: [], pruned: [] };
+}
+
+/**
+ * Merge a local WriteResult into a shared FileDiff tracker.
+ */
+export function recordResult(diff: FileDiff, repoRelPath: string, result: WriteResult): void {
+  if (result === 'written') {
+    diff.written.push(repoRelPath);
+  } else {
+    diff.skipped.push(repoRelPath);
+  }
+}
+
+/**
+ * Convert an absolute path to a repo-relative forward-slash path.
+ */
+export function toRepoRelative(absPath: string, outputDir: string): string {
+  return path.relative(outputDir, absPath).replace(/\\/g, '/');
+}
+
+// ── Hash helper (used internally) ────────────────────────────────────────────
+export function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}

--- a/src/planner.ts
+++ b/src/planner.ts
@@ -45,7 +45,7 @@ function decideAction(
     return {
       path: relPath,
       action: 'update',
-      reason: 'Generator rewrites this artifact each run (instructions are backed up to .bak)',
+      reason: 'Generator rewrites this artifact each run (write-if-changed prevents no-op diffs)',
       risk: relPath.includes('copilot-instructions.md') ? 'medium' : 'low',
     };
   }
@@ -86,6 +86,7 @@ export function buildOnboardingPlan(
   actions.push(decideAction(targetDir, '.github/ai-os/context/existing-ai-context.md', mode, 'always-overwrite'));
   actions.push(decideAction(targetDir, '.github/ai-os/context/dependency-graph.json', mode, 'always-overwrite'));
   actions.push(decideAction(targetDir, '.github/ai-os/config.json', mode, 'always-overwrite'));
+  actions.push(decideAction(targetDir, '.github/ai-os/manifest.json', mode, 'always-overwrite'));
   actions.push(decideAction(targetDir, '.github/ai-os/memory/README.md', mode, 'safe-merge'));
   actions.push(decideAction(targetDir, '.github/ai-os/memory/memory.jsonl', mode, 'safe-merge'));
 

--- a/src/templates/agents/repo-initializer.md
+++ b/src/templates/agents/repo-initializer.md
@@ -46,7 +46,7 @@ bash scripts/ai-os/install.sh
 
 Do not ask for clarification on:
 
-- Code style (follow conventions from `.ai-os/context/conventions.md`)
+- Code style (follow conventions from `{{CONVENTIONS_FILE}}`)
 - File placement (follow the folder structure rules)
 - Naming (follow the naming table in conventions.md)
 


### PR DESCRIPTION
## Summary

Implements all 7 architecture improvement issues filed in the previous session.

### Changes

| Issue | Title | Implementation |
|-------|-------|----------------|
| #7 | Prune stale generated artifacts | `skills.ts` prunes stale `ai-os-*` files in refresh mode; `generate.ts` prunes manifest-tracked files not in current run |
| #8 | ai-os-manifest.json ownership tracking | New `generators/utils.ts` with `writeManifest`/`readManifest`; `generate.ts` writes `.github/ai-os/manifest.json` after every run |
| #9 | Unresolved placeholder leakage | `agents.ts` uses `applyFallbacks()` to strip unresolved `{{PLACEHOLDER}}` tokens instead of writing them to output files |
| #10 | .gitignore completeness | `install.sh` now adds `.github/ai-os/memory/.memory.lock` to `.gitignore` |
| #11 | Generation diff summary | `generate.ts` `printSummary` now shows written/unchanged/pruned counts |
| #12 | --uninstall command | `install.sh --uninstall` reads manifest, confirms with user, removes tracked files, cleans `.gitignore` entries |
| #13 | write-if-changed optimization | New `writeIfChanged()` in `generators/utils.ts`; all generators skip writes when content is unchanged |

### Additional changes
- All generators now return `string[]` of managed absolute paths (required for manifest)
- `planner.ts` adds `.github/ai-os/manifest.json` as an always-overwrite planned action
- `instructions.ts` removes the `.bak` backup (superseded by write-if-changed)