### PR TITLE
fix(security): replace execSync string interpolation with spawnSync in searchFiles (#105)

### DIFF
--- a/src/mcp-server/utils.ts
+++ b/src/mcp-server/utils.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -1367,15 +1367,15 @@ export type { MemoryHygieneSummary };
 
 export function searchFiles(query: string, filePattern?: string, caseSensitive = false): string {
   try {
-    const flags = caseSensitive ? '' : '--ignore-case';
-    const globArg = filePattern ? `-g "${filePattern}"` : '';
-    const cmd = `npx --yes ripgrep ${flags} ${globArg} --line-number --max-count=5 "${query}" "${ROOT}"`;
-    const result = execSync(cmd, { maxBuffer: 512 * 1024, timeout: 10000 }).toString();
-    return result.slice(0, 8000); // Cap output for token efficiency
-  } catch (err) {
-    if (err instanceof Error && 'stdout' in err) {
-      return String((err as NodeJS.ErrnoException & { stdout: Buffer }).stdout ?? 'No results found');
-    }
+    const args = ['--yes', 'ripgrep'];
+    if (!caseSensitive) args.push('--ignore-case');
+    if (filePattern) args.push('-g', filePattern);
+    args.push('--line-number', '--max-count=5', query, ROOT);
+    const result = spawnSync('npx', args, { maxBuffer: 512 * 1024, timeout: 10000, encoding: 'utf-8' });
+    if (result.error) return 'No results found';
+    const output = result.stdout ?? '';
+    return output.slice(0, 8000); // Cap output for token efficiency
+  } catch {
     return 'No results found';
   }
 }

--- a/src/tests/search-files-security.test.ts
+++ b/src/tests/search-files-security.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock must be hoisted before any imports of the module under test
+const mockSpawnSync = vi.fn();
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  spawnSync: mockSpawnSync,
+}));
+
+// ── searchFiles shell-injection regression tests (#105) ────────────────────────
+
+describe('searchFiles – shell injection prevention', () => {
+  beforeEach(() => {
+    mockSpawnSync.mockReturnValue({
+      pid: 1,
+      output: [null, Buffer.from('mock result'), Buffer.from('')],
+      stdout: 'mock result',
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    });
+  });
+
+  it('passes query as a separate array arg, not interpolated into a shell string', async () => {
+    const { searchFiles } = await import('../mcp-server/utils.js');
+    const maliciousQuery = 'foo; rm -rf /';
+    searchFiles(maliciousQuery);
+
+    expect(mockSpawnSync).toHaveBeenCalled();
+    const [cmd, args, opts] = mockSpawnSync.mock.calls[0] as [string, string[], Record<string, unknown>];
+
+    // Must use npx directly (not sh/bash -c)
+    expect(cmd).toBe('npx');
+    expect(cmd).not.toBe('sh');
+    expect(cmd).not.toBe('bash');
+    // query must appear as a standalone array element
+    expect(args).toContain(maliciousQuery);
+    // must NOT be invoked with shell: true (which would allow metachar execution)
+    expect(opts?.shell).toBeFalsy();
+    // no -c flag that would imply shell interpretation
+    expect(args).not.toContain('-c');
+  });
+
+  it('passes filePattern with shell metacharacters as a separate arg', async () => {
+    const { searchFiles } = await import('../mcp-server/utils.js');
+    const maliciousPattern = '*.ts; echo pwned';
+    mockSpawnSync.mockClear();
+    searchFiles('test', maliciousPattern);
+
+    expect(mockSpawnSync).toHaveBeenCalled();
+    const [, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
+
+    expect(args).toContain('-g');
+    // filePattern passed as the next element after -g
+    const gIdx = args.indexOf('-g');
+    expect(args[gIdx + 1]).toBe(maliciousPattern);
+  });
+
+  it('passes backtick in query without executing it', async () => {
+    const { searchFiles } = await import('../mcp-server/utils.js');
+    const backtickQuery = '`whoami`';
+    mockSpawnSync.mockClear();
+    searchFiles(backtickQuery);
+
+    expect(mockSpawnSync).toHaveBeenCalled();
+    const [, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
+    expect(args).toContain(backtickQuery);
+  });
+
+  it('returns "No results found" when spawnSync reports an error', async () => {
+    mockSpawnSync.mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: '',
+      stderr: '',
+      status: 1,
+      signal: null,
+      error: new Error('command failed'),
+    });
+
+    const { searchFiles } = await import('../mcp-server/utils.js');
+    const result = searchFiles('anything');
+    expect(result).toBe('No results found');
+  });
+});
+


### PR DESCRIPTION
## Summary

Fixes #105 — shell injection vulnerability in the `searchFiles` MCP tool.

## Problem

`searchFiles` in `src/mcp-server/utils.ts` interpolated user-controlled `query` and `filePattern` arguments into a shell command string passed to `execSync`:

```ts
const cmd = `npx --yes ripgrep ${flags} ${globArg} --line-number --max-count=5 "${query}" "${ROOT}"`;
execSync(cmd, ...);
```

A crafted query like `foo"; rm -rf / #` or a filePattern containing shell metacharacters could execute arbitrary commands in the user's working directory, since this MCP tool is exposed directly to Copilot agents.

## Fix

- Switches `searchFiles` from `execSync` (string form) to `spawnSync` with array arguments — no shell parsing occurs.
- `spawnSync` is imported alongside the existing `execSync` import (other callsites addressed in #106).

## Tests

Adds `src/tests/search-files-security.test.ts` with 4 regression tests:
- Shell metachar (`;`) in query is passed as a safe array element, not interpreted
- `filePattern` with metacharacters is passed as a separate `-g` arg
- Backtick injection is neutralized
- Error handling returns `'No results found'` when spawnSync errors

## Checklist
- [x] Build passes (`npm run build`)
- [x] All new tests pass (`npx vitest run src/tests/search-files-security.test.ts`)