### PR TITLE
fix(security): replace all remaining string-form execSync with spawnSync (#106)

### DIFF
--- a/src/mcp-server/utils.ts
+++ b/src/mcp-server/utils.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -1519,8 +1519,8 @@ export function getApiRoutes(filter?: string): string {
 
   for (const scan of scanPatterns) {
     try {
-      const cmd = `npx --yes ripgrep --files -g "${scan.glob}" "${ROOT}"`;
-      const files = execSync(cmd, { maxBuffer: 1024 * 1024, timeout: 12000 }).toString().split('\n').filter(Boolean);
+      const scanResult = spawnSync('npx', ['--yes', 'ripgrep', '--files', '-g', scan.glob, ROOT], { maxBuffer: 1024 * 1024, timeout: 12000, encoding: 'utf-8' });
+      const files = (scanResult.stdout ?? '').split('\n').filter(Boolean);
 
       for (const file of files.slice(0, 300)) {
         let content = '';
@@ -1588,8 +1588,8 @@ export function getEnvVars(): string {
 
   for (const extractor of extractors) {
     try {
-      const cmd = `npx --yes ripgrep --files -g "${extractor.fileGlob}" "${ROOT}"`;
-      const files = execSync(cmd, { maxBuffer: 1024 * 1024, timeout: 10000 }).toString().split('\n').filter(Boolean);
+      const extractResult = spawnSync('npx', ['--yes', 'ripgrep', '--files', '-g', extractor.fileGlob, ROOT], { maxBuffer: 1024 * 1024, timeout: 10000, encoding: 'utf-8' });
+      const files = (extractResult.stdout ?? '').split('\n').filter(Boolean);
       for (const file of files.slice(0, 400)) {
         let content = '';
         try {

--- a/src/recommendations/cli-compat.ts
+++ b/src/recommendations/cli-compat.ts
@@ -11,7 +11,7 @@
  * Source-based is the correct, current form. Legacy mode is a fallback for
  * older CLI versions that predate the `<source>@<skill>` positional syntax.
  */
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 /** Skills CLI syntax capability mode. */
 export type SkillsCliMode = 'source-based' | 'legacy';
@@ -32,7 +32,8 @@ export type SkillsCliMode = 'source-based' | 'legacy';
 export function detectSkillsCliMode(opts?: { timeout?: number }): SkillsCliMode {
   const timeout = opts?.timeout ?? 8_000;
   try {
-    const output = execSync('npx -y skills --version 2>&1', { timeout, encoding: 'utf-8' });
+    const result = spawnSync('npx', ['-y', 'skills', '--version'], { timeout, encoding: 'utf-8' });
+    const output = (result.stdout ?? '') + (result.stderr ?? '');
     // Any CLI version that prints a semver string supports source-based syntax.
     // Older pre-release builds (before 1.0) used `--skill` flag only and did
     // not print a standard semver — they typically print nothing or error out.

--- a/src/validation/regression.ts
+++ b/src/validation/regression.ts
@@ -7,7 +7,7 @@
  *
  * Usage:  npm run validate
  */
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -60,9 +60,9 @@ function readText(dir: string, rel: string): string {
 }
 
 function gitInit(dir: string): void {
-  execSync('git init', { cwd: dir, stdio: 'ignore' });
-  execSync('git config user.email "test@ai-os.local"', { cwd: dir, stdio: 'ignore' });
-  execSync('git config user.name "AI OS Test"', { cwd: dir, stdio: 'ignore' });
+  spawnSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+  spawnSync('git', ['config', 'user.email', 'test@ai-os.local'], { cwd: dir, stdio: 'ignore' });
+  spawnSync('git', ['config', 'user.name', 'AI OS Test'], { cwd: dir, stdio: 'ignore' });
 }
 
 const AI_OS_ROOT = path.resolve(import.meta.dirname, '../..');


### PR DESCRIPTION
## Summary

Fixes #106 — hardens all remaining `execSync` callsites by replacing them with `spawnSync` and array arguments.

## Changes

| File | Function | Change |
|---|---|---|
| `src/mcp-server/utils.ts` | `getApiRoutes` | `execSync` string → `spawnSync` array |
| `src/mcp-server/utils.ts` | `getEnvVars` | `execSync` string → `spawnSync` array |
| `src/recommendations/cli-compat.ts` | `detectSkillsCliMode` | `execSync` string → `spawnSync` array; stderr captured alongside stdout |
| `src/validation/regression.ts` | `gitInit` | `execSync` strings → `spawnSync` arrays |

## Notes

- None of the converted callsites received user-controlled input, but switching to `spawnSync` is consistent with the project security posture and enables a future ESLint rule banning string-form `execSync`/`exec`.
- `utils.ts` still imports `execSync` for `searchFiles` — once PR #129 (issue #105) merges, the `execSync` import can be dropped entirely.
- `2>&1` in the `skills --version` probe is now handled by reading both `result.stdout` and `result.stderr`.

## Checklist
- [x] Build passes (`npm run build`)
- [x] `skills-cli-compat` tests pass (16/16)