### PR TITLE
ci: add npm audit gate to CI pipeline (#119)

### DIFF
--- a/.github/workflows/ai-os-validate.yml
+++ b/.github/workflows/ai-os-validate.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Smoke validation (feature health checks)
         run: npm run validate:smoke
 
+      - name: Audit dependencies (high severity)
+        run: npm audit --omit=dev --audit-level=high
+
   validate-full:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -73,3 +76,6 @@ jobs:
 
       - name: Smoke validation (feature health checks)
         run: npm run validate:smoke
+
+      - name: Audit dependencies (high severity)
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## Summary

Closes #119

Adds `npm audit --omit=dev --audit-level=high` as a required step to the CI pipeline, blocking merges when high-severity vulnerabilities are found in production dependencies.

## Changes

### `.github/workflows/ai-os-validate.yml`
- Added **"Audit dependencies (high severity)"** step to `validate-fast` (PR checks) job
- Added **"Audit dependencies (high severity)"** step to `validate-full` (push/dispatch) job

Both jobs now run `npm audit --omit=dev --audit-level=high` after smoke validation. The `--omit=dev` flag excludes devDependencies so only production-impacting vulnerabilities gate the build.

## Behavior

- PRs with high-severity vuln in production deps → CI fails → merge blocked
- PRs with only moderate/low/info vulns → CI passes (expected policy)
- Dev-only deps with any severity → ignored (won't block CI)
- Release workflow is already gated on validate workflow success, so releases are also gated implicitly