### PR TITLE
feat: atomic file writes for all critical artifacts (#110)

### DIFF
--- a/src/detectors/freshness.ts
+++ b/src/detectors/freshness.ts
@@ -7,6 +7,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { writeFileAtomic } from '../generators/utils.js';
 
 // ── Interfaces ─────────────────────────────────────────────────────────────
 
@@ -178,8 +179,7 @@ export function loadContextSnapshot(rootDir: string): ContextSnapshot | null {
 /** Write the context snapshot to `.github/ai-os/context-snapshot.json`. */
 export function writeContextSnapshot(rootDir: string, snapshot: ContextSnapshot): void {
   const snapshotPath = path.join(rootDir, SNAPSHOT_PATH);
-  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
-  fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2), 'utf-8');
+  writeFileAtomic(snapshotPath, JSON.stringify(snapshot, null, 2));
 }
 
 /**

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -14,7 +14,7 @@ import { generateWorkflows } from './generators/workflows.js';
 import { getMcpToolsForStack } from './mcp-tools.js';
 import { checkUpdateStatus, printUpdateBanner, getToolVersion, pruneLegacyArtifacts } from './updater.js';
 import { buildOnboardingPlan, formatOnboardingPlan } from './planner.js';
-import { readManifest, writeManifest, getManifestPath, setVerboseMode } from './generators/utils.js';
+import { readManifest, writeManifest, getManifestPath, setVerboseMode, writeFileAtomic } from './generators/utils.js';
 import { generateRecommendations, getSkillsGapReport } from './recommendations/index.js';
 import { applyProfile, describeProfile, parseProfile } from './profile.js';
 import type { InstallProfile } from './types.js';
@@ -418,7 +418,7 @@ function ensureGitignoreEntry(cwd: string, entry: string): void {
   if (lines.includes(entry)) return;
 
   const next = `${current.replace(/\s*$/, '')}\n${entry}\n`;
-  fs.writeFileSync(gitignorePath, next, 'utf-8');
+  writeFileAtomic(gitignorePath, next);
 }
 
 function resolveBundledServerSource(): string | null {
@@ -455,12 +455,12 @@ function installLocalMcpRuntime(cwd: string, verbose: boolean): void {
   fs.copyFileSync(bundledServerSource, runtimeEntry);
   fs.chmodSync(runtimeEntry, 0o755);
 
-  fs.writeFileSync(runtimeManifest, JSON.stringify({
+  writeFileAtomic(runtimeManifest, JSON.stringify({
     name: 'ai-os-mcp-server',
     runtime: 'bundled',
     sourceVersion: getToolVersion(),
     installedAt: new Date().toISOString(),
-  }, null, 2), 'utf-8');
+  }, null, 2));
 
   // Write the official VS Code MCP config (.vscode/mcp.json) with the resolved
   // Node executable path. This avoids shell alias/PATH issues when VS Code
@@ -667,7 +667,7 @@ async function main(): Promise<void> {
       config = applyProfile(config, effectiveProfile);
       // Persist the profile-applied config back to disk.
       const configPath = path.join(cwd, '.github', 'ai-os', 'config.json');
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+      writeFileAtomic(configPath, JSON.stringify(config, null, 2) + '\n');
     }
   }
 
@@ -774,7 +774,7 @@ async function main(): Promise<void> {
     if (!fs.existsSync(abs)) continue;
     const currentContent = fs.readFileSync(abs, 'utf-8');
     if (currentContent !== originalContent) {
-      fs.writeFileSync(abs, originalContent, 'utf-8');
+      writeFileAtomic(abs, originalContent);
       const rel = path.relative(cwd, abs).replace(/\\/g, '/');
       if (verbose) console.log(`  🔒 restored ${rel}  (protect.json: overwrite reverted)`);
       if (!preservedAbs.some(p => p === abs)) preservedAbs.push(abs);
@@ -793,7 +793,7 @@ async function main(): Promise<void> {
       const rel = path.relative(cwd, abs).replace(/\\/g, '/');
       // Only write when the merge actually changed the content
       if (merged !== generated) {
-        fs.writeFileSync(abs, merged, 'utf-8');
+        writeFileAtomic(abs, merged);
       }
       if (mergedIds.length > 0) {
         if (verbose) {

--- a/src/generators/context-docs.ts
+++ b/src/generators/context-docs.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { DetectedStack, AiOsConfig } from '../types.js';
 import { buildDependencyGraph } from '../detectors/graph.js';
 import { getToolVersion } from '../updater.js';
-import { writeIfChanged } from './utils.js';
+import { writeIfChanged, writeFileAtomic } from './utils.js';
 
 const DEFAULT_AI_OS_CONFIG: Omit<AiOsConfig, 'version' | 'installedAt' | 'projectName' | 'primaryLanguage' | 'primaryFramework' | 'frameworks' | 'packageManager' | 'hasTypeScript'> = {
   agentsMd: false,
@@ -695,10 +695,9 @@ export function generateContextDocs(stack: DetectedStack, outputDir: string, opt
         source: 'ai-os-installer',
       },
     ];
-    fs.writeFileSync(
+    writeFileAtomic(
       memoryFilePath,
       preambleEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
-      'utf-8',
     );
   }
 

--- a/src/generators/mcp.ts
+++ b/src/generators/mcp.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { DetectedStack, AiOsConfig } from '../types.js';
 import { getMcpToolsForStack, getToolsWithStackSplit } from '../mcp-tools.js';
-import { writeIfChanged } from './utils.js';
+import { writeIfChanged, writeFileAtomic } from './utils.js';
 
 interface McpServerConfig {
   type: 'stdio';
@@ -47,8 +47,7 @@ export function writeMcpServerConfig(outputDir: string, options?: WriteMcpServer
   };
   existing.servers = servers;
 
-  fs.mkdirSync(path.dirname(mcpJsonPath), { recursive: true });
-  fs.writeFileSync(mcpJsonPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+  writeFileAtomic(mcpJsonPath, JSON.stringify(existing, null, 2) + '\n');
   return mcpJsonPath;
 }
 

--- a/src/generators/utils.ts
+++ b/src/generators/utils.ts
@@ -16,6 +16,24 @@ export function setVerboseMode(enabled: boolean): void {
 export type WriteResult = 'written' | 'skipped';
 
 /**
+ * Write `content` to `filePath` atomically using a sibling temp-file + rename.
+ * Ensures the parent directory exists before writing.
+ * On POSIX the rename is atomic; on Windows it is best-effort (rename replaces
+ * atomically on NTFS when source and target are on the same volume).
+ */
+export function writeFileAtomic(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(tmpPath, content, 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore cleanup errors */ }
+    throw err;
+  }
+}
+
+/**
  * Write `content` to `filePath` only when the content differs from the existing
  * file. Returns 'written' when a write occurred, 'skipped' when the content was
  * already identical. Ensures the parent directory exists before writing.
@@ -32,7 +50,7 @@ export function writeIfChanged(filePath: string, content: string): WriteResult {
     }
   }
 
-  fs.writeFileSync(filePath, content, 'utf-8');
+  writeFileAtomic(filePath, content);
   if (_verbose) console.log(`  ✏️  write   ${filePath}`);
   return 'written';
 }
@@ -98,10 +116,7 @@ export function writeManifest(outputDir: string, version: string, files: string[
   };
 
   const manifestPath = getManifestPath(outputDir);
-  const tmpPath = manifestPath + '.tmp';
-  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
-  fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2), 'utf-8');
-  fs.renameSync(tmpPath, manifestPath);
+  writeFileAtomic(manifestPath, JSON.stringify(manifest, null, 2));
 }
 
 // ── Diff tracking (#11) ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #110

Adds a `writeFileAtomic(filePath, content)` helper to the generators utility module and migrates all critical write sites to use it, preventing partial writes and corrupt artifacts when the process is interrupted mid-write.

## Changes

### `src/generators/utils.ts`
- Added and exported `writeFileAtomic(filePath, content)`:
  - Writes to a `<target>.tmp-<pid>-<timestamp>` sibling file
  - `fs.renameSync` replaces the target (atomic on POSIX, best-effort on Windows NTFS same-volume)
  - Cleans up the temp file on error before re-throwing
- `writeIfChanged` now delegates the actual write to `writeFileAtomic`
- `writeManifest` simplified to use `writeFileAtomic` (removed inline tmp+rename)

### `src/generators/mcp.ts`
- `.vscode/mcp.json` write → `writeFileAtomic` (also removes redundant `mkdirSync`)

### `src/generators/context-docs.ts`
- Initial `memory.jsonl` preamble write → `writeFileAtomic`

### `src/detectors/freshness.ts`
- `context-snapshot.json` write → `writeFileAtomic`

### `src/generate.ts`
- `.gitignore` append → `writeFileAtomic`
- `runtime-manifest.json` → `writeFileAtomic`
- `config.json` (profile persist) → `writeFileAtomic`
- `protect.json` restore path → `writeFileAtomic`
- Hybrid user-block merge write → `writeFileAtomic`

## Not Changed
`mcp-server/utils.ts` already has its own `writeTextAtomic` and `writeMemoryEntriesAtomic` helpers — left unchanged.

## Test Results
```
Test Files  15 passed (15)
Tests  191 passed (191)
```