### PR TITLE
feat: add --uninstall action (#117)

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -23,11 +23,12 @@ import { mergeUserBlocks } from './user-blocks.js';
 import { runBootstrap, formatBootstrapReport } from './bootstrap.js';
 import { captureContextSnapshot, writeContextSnapshot, computeFreshnessReport, formatFreshnessReport } from './detectors/freshness.js';
 import { runMemoryMaintenance, pruneMemory } from './mcp-server/utils.js';
+import { runUninstall, formatUninstallReport } from './uninstall.js';
 import type { OnboardingPlan } from './planner.js';
 import type { UpdateStatus } from './updater.js';
 
 type GenerateMode = 'safe' | 'refresh-existing' | 'update';
-type GenerateAction = 'apply' | 'plan' | 'preview' | 'check-hygiene' | 'doctor' | 'bootstrap' | 'check-freshness' | 'compact-memory';
+type GenerateAction = 'apply' | 'plan' | 'preview' | 'check-hygiene' | 'doctor' | 'bootstrap' | 'check-freshness' | 'compact-memory' | 'uninstall';
 
 function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action: GenerateAction; prune: boolean; verbose: boolean; cleanUpdate: boolean; regenerateContext: boolean; pruneCustomArtifacts: boolean; profile: InstallProfile | null } {
   const args = process.argv.slice(2);
@@ -78,6 +79,8 @@ function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action
       action = 'check-freshness';
     } else if (args[i] === '--compact-memory') {
       action = 'compact-memory';
+    } else if (args[i] === '--uninstall') {
+      action = 'uninstall';
     } else if (args[i] === '--verbose' || args[i] === '-v') {
       verbose = true;
     } else if (args[i] === '--regenerate-context') {
@@ -539,6 +542,13 @@ async function main(): Promise<void> {
   // ── --compact-memory action (runs before scan, no generation needed) ───────
   if (action === 'compact-memory') {
     runCompactMemory(cwd);
+    return;
+  }
+
+  // ── --uninstall action ────────────────────────────────────────────────────
+  if (action === 'uninstall') {
+    const report = runUninstall(cwd, { dryRun, verbose });
+    console.log(formatUninstallReport(report));
     return;
   }
 

--- a/src/tests/uninstall.test.ts
+++ b/src/tests/uninstall.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { runUninstall, formatUninstallReport } from '../uninstall.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  const d = path.join(os.tmpdir(), `ai-os-uninstall-${Date.now()}`);
+  fs.mkdirSync(d, { recursive: true });
+  return d;
+}
+
+function writeFile(dir: string, rel: string, content: string): string {
+  const abs = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+  return abs;
+}
+
+function writeManifest(dir: string, files: string[]): void {
+  const manifestPath = path.join(dir, '.github', 'ai-os', 'manifest.json');
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, JSON.stringify({ version: '0.0.0', generatedAt: '', files }), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runUninstall', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty report when no manifest exists', () => {
+    const report = runUninstall(tmpDir);
+    expect(report.removed).toHaveLength(0);
+    expect(report.skipped).toHaveLength(0);
+    expect(report.notFound).toHaveLength(0);
+    expect(report.errors).toHaveLength(0);
+  });
+
+  it('removes files listed in manifest', () => {
+    writeFile(tmpDir, '.github/copilot-instructions.md', '# Instructions');
+    writeFile(tmpDir, '.github/agents/expert.agent.md', '# Agent');
+    writeManifest(tmpDir, ['.github/copilot-instructions.md', '.github/agents/expert.agent.md']);
+
+    const report = runUninstall(tmpDir, { verbose: false });
+
+    expect(report.removed).toContain('.github/copilot-instructions.md');
+    expect(report.removed).toContain('.github/agents/expert.agent.md');
+    expect(fs.existsSync(path.join(tmpDir, '.github/copilot-instructions.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.github/agents/expert.agent.md'))).toBe(false);
+  });
+
+  it('records not-found files gracefully', () => {
+    writeManifest(tmpDir, ['.github/some-missing-file.md']);
+
+    const report = runUninstall(tmpDir);
+
+    expect(report.notFound).toContain('.github/some-missing-file.md');
+    expect(report.removed).toHaveLength(0);
+  });
+
+  it('dry-run does not delete files', () => {
+    writeFile(tmpDir, '.github/copilot-instructions.md', '# Instructions');
+    writeManifest(tmpDir, ['.github/copilot-instructions.md']);
+
+    const report = runUninstall(tmpDir, { dryRun: true });
+
+    expect(report.removed).toContain('.github/copilot-instructions.md');
+    expect(report.dryRun).toBe(true);
+    // File must still exist
+    expect(fs.existsSync(path.join(tmpDir, '.github/copilot-instructions.md'))).toBe(true);
+  });
+
+  it('skips files protected by protect.json', () => {
+    writeFile(tmpDir, '.github/copilot-instructions.md', '# My Instructions');
+    writeFile(tmpDir, '.github/ai-os/protect.json', JSON.stringify({
+      never: ['.github/copilot-instructions.md'],
+    }));
+    writeManifest(tmpDir, ['.github/copilot-instructions.md']);
+
+    const report = runUninstall(tmpDir);
+
+    expect(report.skipped).toContain('.github/copilot-instructions.md');
+    expect(report.removed).toHaveLength(0);
+    expect(fs.existsSync(path.join(tmpDir, '.github/copilot-instructions.md'))).toBe(true);
+  });
+
+  it('skips files that contain user blocks', () => {
+    const content = [
+      '# Instructions',
+      '',
+      '<!-- AI-OS:USER_BLOCK:START id="my-block" -->',
+      'My custom content',
+      '<!-- AI-OS:USER_BLOCK:END id="my-block" -->',
+    ].join('\n');
+    writeFile(tmpDir, '.github/copilot-instructions.md', content);
+    writeManifest(tmpDir, ['.github/copilot-instructions.md']);
+
+    const report = runUninstall(tmpDir);
+
+    expect(report.skipped).toContain('.github/copilot-instructions.md');
+    expect(report.removed).toHaveLength(0);
+    expect(fs.existsSync(path.join(tmpDir, '.github/copilot-instructions.md'))).toBe(true);
+  });
+
+  it('report.dryRun reflects the dryRun option', () => {
+    writeManifest(tmpDir, []);
+    const dry = runUninstall(tmpDir, { dryRun: true });
+    expect(dry.dryRun).toBe(true);
+    const wet = runUninstall(tmpDir, { dryRun: false });
+    expect(wet.dryRun).toBe(false);
+  });
+});
+
+describe('formatUninstallReport', () => {
+  it('includes removed count', () => {
+    const report = {
+      cwd: '/some/dir',
+      dryRun: false,
+      removed: ['a.md', 'b.md'],
+      skipped: [],
+      notFound: [],
+      errors: [],
+    };
+    const text = formatUninstallReport(report);
+    expect(text).toContain('Removed:   2');
+  });
+
+  it('includes [DRY RUN] tag when dryRun is true', () => {
+    const report = {
+      cwd: '/some/dir',
+      dryRun: true,
+      removed: [],
+      skipped: [],
+      notFound: [],
+      errors: [],
+    };
+    expect(formatUninstallReport(report)).toContain('[DRY RUN]');
+  });
+});

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -1,0 +1,201 @@
+/**
+ * AI OS Uninstall
+ *
+ * Removes all files that AI OS owns (per manifest.json) from the project.
+ * Preserves any files listed in protect.json or that contain user-block markers.
+ * Supports --dry-run mode.
+ *
+ * Managed directories (.ai-os/, .github/ai-os/) are removed when empty after
+ * file deletion.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { readManifest } from './generators/utils.js';
+import { extractUserBlocks } from './user-blocks.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface UninstallReport {
+  cwd: string;
+  dryRun: boolean;
+  removed: string[];
+  skipped: string[];
+  notFound: string[];
+  errors: Array<{ file: string; reason: string }>;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function readProtectedPaths(cwd: string): Set<string> {
+  const protectPath = path.join(cwd, '.github', 'ai-os', 'protect.json');
+  if (!fs.existsSync(protectPath)) return new Set();
+  try {
+    const raw = JSON.parse(fs.readFileSync(protectPath, 'utf-8')) as unknown;
+    if (!raw || typeof raw !== 'object') return new Set();
+    const obj = raw as Record<string, unknown>;
+    const files: string[] = [];
+    if (Array.isArray(obj['never'])) {
+      files.push(...(obj['never'] as string[]));
+    }
+    if (Array.isArray(obj['hybrid'])) {
+      files.push(...(obj['hybrid'] as string[]));
+    }
+    // Resolve relative paths to absolute
+    return new Set(files.map(f => path.resolve(cwd, f)));
+  } catch {
+    return new Set();
+  }
+}
+
+function hasUserBlocks(filePath: string): boolean {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const blocks = extractUserBlocks(content);
+    return blocks.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function removeEmptyDirs(dirs: string[]): void {
+  // Sort deepest first so inner dirs are tried before parents
+  const sorted = [...dirs].sort((a, b) => b.length - a.length);
+  for (const dir of sorted) {
+    try {
+      if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) {
+        fs.rmdirSync(dir);
+      }
+    } catch { /* best effort */ }
+  }
+}
+
+// ── Core uninstall logic ──────────────────────────────────────────────────────
+
+export function runUninstall(cwd: string, options: { dryRun?: boolean; verbose?: boolean } = {}): UninstallReport {
+  const { dryRun = false, verbose = false } = options;
+
+  const report: UninstallReport = {
+    cwd,
+    dryRun,
+    removed: [],
+    skipped: [],
+    notFound: [],
+    errors: [],
+  };
+
+  const manifest = readManifest(cwd);
+  if (!manifest) {
+    console.log('  ℹ️  No AI OS manifest found — nothing to uninstall.');
+    return report;
+  }
+
+  const protected_ = readProtectedPaths(cwd);
+  const affectedDirs = new Set<string>();
+
+  for (const relPath of manifest.files) {
+    const abs = path.resolve(cwd, relPath);
+
+    if (!fs.existsSync(abs)) {
+      report.notFound.push(relPath);
+      if (verbose) console.log(`  ❓ not found  ${relPath}`);
+      continue;
+    }
+
+    // Skip files protected by protect.json
+    if (protected_.has(abs)) {
+      report.skipped.push(relPath);
+      if (verbose) console.log(`  🔒 skipped    ${relPath}  (protect.json)`);
+      continue;
+    }
+
+    // Skip files that contain user-authored content blocks
+    if (hasUserBlocks(abs)) {
+      report.skipped.push(relPath);
+      if (verbose) console.log(`  🔒 skipped    ${relPath}  (has user blocks)`);
+      continue;
+    }
+
+    if (dryRun) {
+      report.removed.push(relPath);
+      console.log(`  🗑️  [dry-run]   ${relPath}`);
+      continue;
+    }
+
+    try {
+      fs.unlinkSync(abs);
+      report.removed.push(relPath);
+      affectedDirs.add(path.dirname(abs));
+      if (verbose) console.log(`  🗑️  removed    ${relPath}`);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      report.errors.push({ file: relPath, reason });
+      console.error(`  ✖ error       ${relPath}: ${reason}`);
+    }
+  }
+
+  // Also remove AI OS runtime directory and manifest itself
+  const managedDirs = [
+    path.join(cwd, '.ai-os', 'mcp-server'),
+    path.join(cwd, '.ai-os'),
+  ];
+  const manifestPath = path.join(cwd, '.github', 'ai-os', 'manifest.json');
+
+  if (!dryRun) {
+    for (const dir of managedDirs) {
+      try {
+        if (fs.existsSync(dir)) {
+          fs.rmSync(dir, { recursive: true, force: true });
+          if (verbose) console.log(`  🗑️  removed    ${path.relative(cwd, dir)}/`);
+        }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.error(`  ✖ error       ${path.relative(cwd, dir)}: ${reason}`);
+      }
+    }
+
+    // Remove the manifest last
+    try {
+      if (fs.existsSync(manifestPath)) {
+        fs.unlinkSync(manifestPath);
+        if (verbose) console.log(`  🗑️  removed    .github/ai-os/manifest.json`);
+      }
+    } catch { /* ignore */ }
+
+    // Prune empty managed directories
+    const dirsToCheck = [
+      ...Array.from(affectedDirs),
+      path.join(cwd, '.github', 'ai-os'),
+      path.join(cwd, '.github', 'agents'),
+      path.join(cwd, '.github', 'copilot', 'skills'),
+      path.join(cwd, '.github', 'copilot'),
+      path.join(cwd, '.github', 'instructions'),
+    ];
+    removeEmptyDirs(dirsToCheck);
+  }
+
+  return report;
+}
+
+export function formatUninstallReport(report: UninstallReport): string {
+  const lines: string[] = [];
+  const mode = report.dryRun ? ' [DRY RUN]' : '';
+
+  lines.push(`\n  ✅ AI OS uninstall complete${mode}`);
+  lines.push(`     Removed:   ${report.removed.length} file(s)`);
+  if (report.skipped.length > 0) lines.push(`     Skipped:   ${report.skipped.length} file(s)  (user content preserved)`);
+  if (report.notFound.length > 0) lines.push(`     Not found: ${report.notFound.length} file(s)`);
+  if (report.errors.length > 0) lines.push(`     Errors:    ${report.errors.length} file(s)`);
+
+  if (report.skipped.length > 0) {
+    lines.push('\n  Files skipped (contain user content):');
+    for (const f of report.skipped) lines.push(`    • ${f}`);
+  }
+
+  if (report.errors.length > 0) {
+    lines.push('\n  Errors:');
+    for (const e of report.errors) lines.push(`    • ${e.file}: ${e.reason}`);
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Closes #117

Adds a `--uninstall` action that removes all AI OS-owned files from a project while preserving user-authored content.

## Usage

```bash
npx -y github:marinvch/ai-os --uninstall             # remove all AI OS files
npx -y github:marinvch/ai-os --uninstall --dry-run   # preview what would be removed
npx -y github:marinvch/ai-os --uninstall --cwd /path/to/project
npx -y github:marinvch/ai-os --uninstall --verbose   # per-file log
```

## Changes

### `src/uninstall.ts` (new)
- `runUninstall(cwd, {dryRun, verbose})` — reads `manifest.json`, removes AI OS-owned files
- Skips files listed in `protect.json` (`never` or `hybrid` arrays)
- Skips files containing `<!-- AI-OS:USER_BLOCK:START ... -->` markers
- Removes `.ai-os/` runtime directory and `manifest.json` itself
- Prunes empty managed directories after file deletion
- Returns `UninstallReport` with `removed`, `skipped`, `notFound`, `errors` arrays
- `formatUninstallReport(report)` — human-readable summary

### `src/generate.ts`
- Added `'uninstall'` to `GenerateAction` union type
- Added `--uninstall` CLI flag parsing
- Added handler block (runs before stack scan, consistent with `--doctor`, `--compact-memory`, etc.)

### `src/tests/uninstall.test.ts` (new)
- 9 tests covering: no manifest, file removal, not-found, dry-run, protect.json skip, user-blocks skip, dryRun flag, formatUninstallReport

## Test Results

```
Test Files  16 passed (16)
Tests  200 passed (200)
```