### PR TITLE
feat: add runtime type guards for JSON artifacts (#109)

### DIFF
--- a/src/generators/context-docs.ts
+++ b/src/generators/context-docs.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { DetectedStack, AiOsConfig } from '../types.js';
+import { isAiOsConfig } from '../types.js';
 import { buildDependencyGraph } from '../detectors/graph.js';
 import { getToolVersion } from '../updater.js';
 import { writeIfChanged } from './utils.js';
@@ -22,7 +23,12 @@ const DEFAULT_AI_OS_CONFIG: Omit<AiOsConfig, 'version' | 'installedAt' | 'projec
 export function readAiOsConfig(outputDir: string): AiOsConfig | null {
   const configPath = path.join(outputDir, '.github', 'ai-os', 'config.json');
   try {
-    return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as AiOsConfig;
+    const parsed: unknown = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    if (!isAiOsConfig(parsed)) {
+      console.warn(`⚠️  config.json at ${configPath} failed schema validation — ignoring.`);
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }

--- a/src/generators/utils.ts
+++ b/src/generators/utils.ts
@@ -77,10 +77,27 @@ export function getManifestPath(outputDir: string): string {
   return path.join(outputDir, '.github', 'ai-os', MANIFEST_FILENAME);
 }
 
+/** Runtime type guard for AiOsManifest JSON artifacts. */
+export function isAiOsManifest(obj: unknown): obj is AiOsManifest {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o['version'] === 'string' &&
+    typeof o['generatedAt'] === 'string' &&
+    Array.isArray(o['files']) &&
+    (o['files'] as unknown[]).every((f) => typeof f === 'string')
+  );
+}
+
 export function readManifest(outputDir: string): AiOsManifest | null {
   const manifestPath = getManifestPath(outputDir);
   try {
-    return JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as AiOsManifest;
+    const parsed: unknown = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    if (!isAiOsManifest(parsed)) {
+      console.warn(`⚠️  manifest.json at ${manifestPath} failed schema validation — ignoring.`);
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }

--- a/src/tests/schema-validate.test.ts
+++ b/src/tests/schema-validate.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { isAiOsConfig } from '../types.js';
+import { isAiOsManifest } from '../generators/utils.js';
+
+describe('isAiOsManifest', () => {
+  const valid = {
+    version: '0.11.0',
+    generatedAt: '2024-01-01T00:00:00.000Z',
+    files: ['.github/copilot-instructions.md'],
+  };
+
+  it('accepts a valid manifest', () => {
+    expect(isAiOsManifest(valid)).toBe(true);
+  });
+
+  it('accepts empty files array', () => {
+    expect(isAiOsManifest({ ...valid, files: [] })).toBe(true);
+  });
+
+  it('rejects null', () => {
+    expect(isAiOsManifest(null)).toBe(false);
+  });
+
+  it('rejects missing version', () => {
+    const { version: _, ...rest } = valid;
+    expect(isAiOsManifest(rest)).toBe(false);
+  });
+
+  it('rejects non-string in files array', () => {
+    expect(isAiOsManifest({ ...valid, files: [42] })).toBe(false);
+  });
+
+  it('rejects a plain string', () => {
+    expect(isAiOsManifest('not an object')).toBe(false);
+  });
+});
+
+describe('isAiOsConfig', () => {
+  const valid = {
+    version: '0.11.0',
+    installedAt: '2024-01-01T00:00:00.000Z',
+    projectName: 'my-project',
+    primaryLanguage: 'TypeScript',
+    primaryFramework: null,
+    frameworks: [],
+    packageManager: 'npm',
+    hasTypeScript: true,
+    agentsMd: false,
+    pathSpecificInstructions: true,
+    recommendations: true,
+    sessionContextCard: true,
+    updateCheckEnabled: true,
+    persistentRules: [],
+    exclude: [],
+  };
+
+  it('accepts a valid config', () => {
+    expect(isAiOsConfig(valid)).toBe(true);
+  });
+
+  it('rejects null', () => {
+    expect(isAiOsConfig(null)).toBe(false);
+  });
+
+  it('rejects missing version', () => {
+    const { version: _, ...rest } = valid;
+    expect(isAiOsConfig(rest)).toBe(false);
+  });
+
+  it('rejects hasTypeScript as string', () => {
+    expect(isAiOsConfig({ ...valid, hasTypeScript: 'true' })).toBe(false);
+  });
+
+  it('rejects persistentRules as string', () => {
+    expect(isAiOsConfig({ ...valid, persistentRules: 'rule' })).toBe(false);
+  });
+
+  it('rejects missing exclude', () => {
+    const { exclude: _, ...rest } = valid;
+    expect(isAiOsConfig(rest)).toBe(false);
+  });
+
+  it('accepts optional fields being absent', () => {
+    // skillsStrategy, profile, memoryTtlDays etc. are optional
+    expect(isAiOsConfig(valid)).toBe(true);
+  });
+
+  it('rejects a plain array', () => {
+    expect(isAiOsConfig([])).toBe(false);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,3 +158,19 @@ export interface AiOsConfig {
    */
   memoryNearDuplicateThreshold?: number;
 }
+
+/** Runtime type guard for AiOsConfig JSON artifacts. */
+export function isAiOsConfig(obj: unknown): obj is AiOsConfig {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o['version'] === 'string' &&
+    typeof o['installedAt'] === 'string' &&
+    typeof o['projectName'] === 'string' &&
+    typeof o['primaryLanguage'] === 'string' &&
+    typeof o['packageManager'] === 'string' &&
+    typeof o['hasTypeScript'] === 'boolean' &&
+    Array.isArray(o['persistentRules']) &&
+    Array.isArray(o['exclude'])
+  );
+}


### PR DESCRIPTION
## Summary

Closes #109

Adds runtime type guards for AI OS JSON artifacts so that corrupt or schema-mismatched files fail gracefully with a diagnostic warning instead of silently propagating invalid data.

## Changes

### `src/types.ts`
- `isAiOsConfig(obj): obj is AiOsConfig` — validates all required fields (version, installedAt, projectName, primaryLanguage, packageManager, hasTypeScript, persistentRules[], exclude[])

### `src/generators/utils.ts`
- `isAiOsManifest(obj): obj is AiOsManifest` — validates version, generatedAt, and files[] (all strings)
- `readManifest()` now uses the guard; logs `⚠️` warning and returns `null` on mismatch

### `src/generators/context-docs.ts`
- `readAiOsConfig()` now uses `isAiOsConfig`; logs `⚠️` warning and returns `null` on mismatch

### `src/tests/schema-validate.test.ts` (new)
- 14 tests covering both guards: valid input, null, missing required fields, wrong types

## Test Results

```
Test Files  16 passed (16)
Tests  205 passed (205)
```