### PR TITLE
feat: auto-run --doctor after install (#123)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -588,6 +588,17 @@ if [[ -f "$GITIGNORE" ]]; then
   fi
 fi
 
+# ── Post-install health check (--doctor) ─────────────────────────────────────
+echo -e "  ${CYAN}→ Running post-install health check...${RESET}"
+if (cd "$AIOS_SRC" && AI_OS_NODE_PATH="$NODE_ABS_PATH" "$NODE_ABS_PATH" --import tsx/esm src/generate.ts --doctor --cwd "$TARGET_DIR"); then
+  echo -e "  ${GREEN}✓ Health check passed${RESET}"
+else
+  echo ""
+  echo -e "  ${YELLOW}⚠ Health check found issues (see above). AI OS is installed but may need attention.${RESET}"
+  echo -e "  ${YELLOW}  Re-run diagnostics:${RESET} npx -y github:marinvch/ai-os --doctor --cwd ."
+fi
+echo ""
+
 # ── Done ────────────────────────────────────────────────────────────────────
 echo ""
 echo -e "  ${GREEN}${BOLD}✅ AI OS installed successfully!${RESET}"


### PR DESCRIPTION
## Summary

Closes #123

Automatically runs `--doctor` at the end of every `install.sh` execution so users see a health report immediately after installation without needing to run a separate command.

## Changes

### `install.sh`
- Added a **post-install health check** step after all artifact generation, MCP server install, and `.gitignore` updates
- Uses the same `node --import tsx/esm src/generate.ts --doctor --cwd "$TARGET_DIR"` invocation pattern as the rest of the install script
- On **success**: prints `✓ Health check passed`
- On **failure**: prints a non-fatal yellow warning with the re-run command; the install **does not abort** — doctor failures are informational (node connectivity issues, optional tools)
- Provides the re-run hint: `npx -y github:marinvch/ai-os --doctor --cwd .`

## Behavior

```
→ Running post-install health check...
✓ Health check passed

✅ AI OS installed successfully!
```

Or on partial failure:
```
→ Running post-install health check...
⚠ Health check found issues (see above). AI OS is installed but may need attention.
  Re-run diagnostics: npx -y github:marinvch/ai-os --doctor --cwd .
```