### PR TITLE
feat: content-hash gate for generated artifacts (#115)

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -14,7 +14,7 @@ import { generateWorkflows } from './generators/workflows.js';
 import { getMcpToolsForStack } from './mcp-tools.js';
 import { checkUpdateStatus, printUpdateBanner, getToolVersion, pruneLegacyArtifacts } from './updater.js';
 import { buildOnboardingPlan, formatOnboardingPlan } from './planner.js';
-import { readManifest, writeManifest, getManifestPath, setVerboseMode } from './generators/utils.js';
+import { readManifest, writeManifest, getManifestPath, setVerboseMode, hashFile } from './generators/utils.js';
 import { generateRecommendations, getSkillsGapReport } from './recommendations/index.js';
 import { applyProfile, describeProfile, parseProfile } from './profile.js';
 import type { InstallProfile } from './types.js';
@@ -817,8 +817,16 @@ async function main(): Promise<void> {
     console.log('');
   }
 
-  // Write updated manifest (#8 / #11).
-  writeManifest(cwd, getToolVersion(), currentRelFiles);
+  // Write updated manifest (#8 / #11 / #115).
+  // Compute SHA-256 hashes for all managed files so future refresh runs
+  // can detect which files have drifted from the generated baseline.
+  const contentHashes: Record<string, string> = {};
+  for (const rel of currentRelFiles) {
+    if (rel === manifestRel) continue;
+    const hash = hashFile(path.join(cwd, rel));
+    if (hash) contentHashes[rel] = hash;
+  }
+  writeManifest(cwd, getToolVersion(), currentRelFiles, contentHashes);
 
   // ── Capture context freshness snapshot ──────────────────────────────────
   // After a successful generation run, record a new baseline snapshot so that

--- a/src/generators/utils.ts
+++ b/src/generators/utils.ts
@@ -11,6 +11,29 @@ export function setVerboseMode(enabled: boolean): void {
   _verbose = enabled;
 }
 
+// ── Content hashing (#115) ────────────────────────────────────────────────────
+
+/**
+ * Compute a SHA-256 hex digest of `content`.
+ * Used to populate manifest.hashes so refresh runs can detect unchanged files.
+ */
+export function hashContent(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+/**
+ * Read a file from disk and compute its SHA-256 hex digest.
+ * Returns `null` when the file does not exist.
+ */
+export function hashFile(filePath: string): string | null {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    return hashContent(content);
+  } catch {
+    return null;
+  }
+}
+
 // ── Write-if-changed (#13) ────────────────────────────────────────────────────
 
 export type WriteResult = 'written' | 'skipped';
@@ -69,6 +92,8 @@ export interface AiOsManifest {
   generatedAt: string;
   /** Repo-relative paths of all files written by AI OS in this run */
   files: string[];
+  /** SHA-256 content hashes keyed by repo-relative file path */
+  hashes?: Record<string, string>;
 }
 
 const MANIFEST_FILENAME = 'manifest.json';
@@ -89,12 +114,19 @@ export function readManifest(outputDir: string): AiOsManifest | null {
 /**
  * Write the manifest atomically: write to a temp file then rename.
  * `files` should be repo-relative paths (forward slashes).
+ * `hashes` is an optional map of repo-relative path → SHA-256 hex content hash.
  */
-export function writeManifest(outputDir: string, version: string, files: string[]): void {
+export function writeManifest(
+  outputDir: string,
+  version: string,
+  files: string[],
+  hashes?: Record<string, string>,
+): void {
   const manifest: AiOsManifest = {
     version,
     generatedAt: new Date().toISOString(),
     files: [...files].sort(),
+    ...(hashes && Object.keys(hashes).length > 0 ? { hashes } : {}),
   };
 
   const manifestPath = getManifestPath(outputDir);


### PR DESCRIPTION
## Summary

Closes #115

Adds content-hash tracking per generated artifact so that `--refresh-existing` runs can detect file drift and future tooling can skip unchanged files without re-reading or re-generating them.

## Changes

### `src/generators/utils.ts`
- `hashContent(content): string` — computes SHA-256 hex digest of a UTF-8 string
- `hashFile(filePath): string | null` — reads a file from disk and returns its SHA-256 hash
- `AiOsManifest` extended with optional `hashes?: Record<string, string>` field
- `writeManifest()` accepts an optional `hashes` param and includes it in the written JSON

### `src/generate.ts`
- Imports `hashFile` from `./generators/utils.js`
- After all generation and file writes, computes SHA-256 content hashes for every managed file (excluding `manifest.json` itself)
- Passes the hashes map to `writeManifest()` so `manifest.json` records the post-generation baseline
- Future `--refresh-existing` runs can compare current file hashes against `manifest.hashes` to detect drift at a glance

## Design Notes

`writeIfChanged()` already skips write-on-disk when content is byte-identical — the hash gate adds a **persistent baseline** so callers can detect user-modified files and surface drift without requiring a full generation pass. The `isAiOsManifest()` type guard is unaffected because `hashes` is optional.

## Test Results

```
Test Files  15 passed (15)
Tests  191 passed (191)
```