### PR TITLE
feat: add Prompt Quality Pack generated artifact (#127)

### DIFF
--- a/src/generators/instructions.ts
+++ b/src/generators/instructions.ts
@@ -430,5 +430,146 @@ export function generateInstructions(stack: DetectedStack, outputDir: string, op
     outputFiles.push(...pathSpecificFiles);
   }
 
+  // Generate Prompt Quality Pack unless explicitly disabled
+  if (config?.promptQualityPack !== false) {
+    const pqpPath = generatePromptQualityPack(stack, outputDir, githubDir);
+    if (pqpPath) outputFiles.push(pqpPath);
+  }
+
   return outputFiles;
+}
+
+function generatePromptQualityPack(stack: DetectedStack, outputDir: string, githubDir: string): string | null {
+  const agentsDir = path.join(outputDir, '.github', 'agents');
+  const skillsDir = path.join(outputDir, '.github', 'copilot', 'skills');
+
+  // Discover installed agents
+  const agentRows: string[] = [];
+  if (fs.existsSync(agentsDir)) {
+    for (const file of fs.readdirSync(agentsDir)) {
+      if (!file.endsWith('.agent.md')) continue;
+      try {
+        const raw = fs.readFileSync(path.join(agentsDir, file), 'utf-8');
+        const nameMatch = raw.match(/^name:\s*(.+)$/m);
+        const argHintMatch = raw.match(/^argument-hint:\s*"?(.+?)"?$/m);
+        const descMatch = raw.match(/^description:\s*(.+)$/m);
+        const name = nameMatch?.[1]?.trim() ?? file.replace('.agent.md', '');
+        const argHint = argHintMatch?.[1]?.trim() ?? '';
+        const desc = descMatch?.[1]?.trim() ?? '';
+        agentRows.push(`| \`${name}\` | ${desc} | ${argHint} |`);
+      } catch {
+        // skip unreadable agent files
+      }
+    }
+  }
+
+  // Discover installed skills
+  const skillRows: string[] = [];
+  if (fs.existsSync(skillsDir)) {
+    for (const file of fs.readdirSync(skillsDir)) {
+      if (!file.endsWith('.md')) continue;
+      try {
+        const raw = fs.readFileSync(path.join(skillsDir, file), 'utf-8');
+        const nameMatch = raw.match(/^name:\s*(.+)$/m);
+        const triggerMatch = raw.match(/^description:\s*(.+)$/m);
+        const name = nameMatch?.[1]?.trim() ?? file.replace('.md', '');
+        const trigger = triggerMatch?.[1]?.trim() ?? '';
+        skillRows.push(`| \`${name}\` | ${trigger} |`);
+      } catch {
+        // skip unreadable skill files
+      }
+    }
+  }
+
+  const agentTable = agentRows.length > 0
+    ? ['| Agent | Description | When to use |', '|---|---|---|', ...agentRows].join('\n')
+    : '_No agents installed yet._';
+
+  const skillTable = skillRows.length > 0
+    ? ['| Skill | Trigger phrase / description |', '|---|---|', ...skillRows].join('\n')
+    : '_No skills installed yet._';
+
+  const frameworks = stack.frameworks.map(f => f.name).join(', ') || stack.primaryLanguage.name;
+  const buildCmd = stack.buildCommands?.build ?? 'npm run build';
+  const testCmd = stack.buildCommands?.test ?? 'npm test';
+  const contextSyncCmd = 'npx -y github:marinvch/ai-os --refresh-existing';
+
+  const content = [
+    '---',
+    'applyTo: "**"',
+    '---',
+    '',
+    `# Prompt Quality Pack — ${stack.projectName}`,
+    '',
+    `> Stack: **${frameworks}** · Language: **${stack.primaryLanguage.name}** · Package manager: **${stack.patterns.packageManager}**`,
+    '',
+    '## 1. Prompt Template',
+    '',
+    'Use this structure for best results:',
+    '',
+    '```',
+    'Goal: <one sentence — what should be accomplished>',
+    'Scope: #file:<path> or describe the affected area',
+    'Constraints: <framework rules, must-nots, or size limits>',
+    'Agent: <agent name if a specialist is needed>',
+    'Skill: <skill keyword if domain-specific guidance is needed>',
+    'Done-when: <acceptance criteria — how will we know it worked?>',
+    '```',
+    '',
+    '## 2. Agent Routing Table',
+    '',
+    'Use `@<agent-name>` to invoke a specialist agent:',
+    '',
+    agentTable,
+    '',
+    '## 3. Skill Trigger Keywords',
+    '',
+    'Skills load automatically when your prompt matches their description:',
+    '',
+    skillTable,
+    '',
+    '## 4. MCP Health Check',
+    '',
+    'Verify the MCP server is connected before starting a session.',
+    'If `get_session_context` or `get_repo_memory` returns no output, the server is not running.',
+    'Restart it via the VS Code MCP panel or re-run the install.',
+    '',
+    '## 5. Plan-Mode Trigger',
+    '',
+    'Switch to **Plan mode** first when:',
+    '- The task has 3 or more sequential steps',
+    '- The change is irreversible (delete, drop, migrate, deploy)',
+    '- Multiple files or systems are affected',
+    '',
+    '## 6. Post-Change Context Refresh',
+    '',
+    'After structural changes (new dependencies, new files, architecture moves), refresh AI OS context:',
+    '',
+    '```bash',
+    contextSyncCmd,
+    '```',
+    '',
+    '## 7. Anti-Patterns',
+    '',
+    '- **Mixing concerns** — one prompt should do one thing',
+    `- **Vague \`#codebase\`** when a specific file path is known — use \`#file:<path>\``,
+    '- **Accepting unsourced claims** — verify with `get_repo_memory` or `search_codebase`',
+    '- **Skipping Plan mode** for irreversible changes',
+    '- **Ignoring stale context** — run `check_for_updates` if output quality drops',
+    '',
+    '## Build & Test Commands',
+    '',
+    `| Action | Command |`,
+    `|---|---|`,
+    `| Build | \`${buildCmd}\` |`,
+    `| Test | \`${testCmd}\` |`,
+  ].join('\n');
+
+  const instructionsDir = path.join(githubDir, 'instructions');
+  if (!fs.existsSync(instructionsDir)) {
+    fs.mkdirSync(instructionsDir, { recursive: true });
+  }
+  const outputPath = path.join(instructionsDir, 'prompt-quality.instructions.md');
+  writeIfChanged(outputPath, content);
+  return outputPath;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,4 +157,9 @@ export interface AiOsConfig {
    * Range: 0.5–1.0. Default: 0.85.
    */
   memoryNearDuplicateThreshold?: number;
+  /**
+   * When false, skip generating .github/instructions/prompt-quality.instructions.md.
+   * Default: true.
+   */
+  promptQualityPack?: boolean;
 }


### PR DESCRIPTION
## Summary

Closes #127

Adds an opt-in **Prompt Quality Pack** that is generated automatically on every `--refresh-existing` run.

## Changes

### `src/generators/instructions.ts`
- Added `generatePromptQualityPack(stack, outputDir, githubDir)` function
- Generates `.github/instructions/prompt-quality.instructions.md` with `applyTo: **`
- Wired into `generateInstructions()` after path-specific instructions, unless `config.promptQualityPack === false`

### `src/types.ts`
- Added `promptQualityPack?: boolean` to `AiOsConfig` (default: `true`, set `false` to opt-out)

## Generated file sections

1. **Prompt template** — Goal / Scope / Constraints / Agent / Skill hints / Done-when
2. **Agent routing table** — auto-built from `.github/agents/*.agent.md`
3. **Skill trigger keywords** — auto-built from `.github/copilot/skills/*.md`
4. **MCP health check** — verify server connectivity
5. **Plan-mode trigger** — when to switch to Plan first
6. **Post-change context refresh** — run `--refresh-existing` after structural changes
7. **Anti-patterns** — common prompting mistakes to avoid

The file uses `applyTo: **` so VS Code Copilot loads it on every conversation.