### PR TITLE
ci: add self-hosted scorecard regression check (#121)

### DIFF
--- a/.github/workflows/ai-os-validate.yml
+++ b/.github/workflows/ai-os-validate.yml
@@ -73,3 +73,33 @@ jobs:
 
       - name: Smoke validation (feature health checks)
         run: npm run validate:smoke
+
+      - name: Scorecard regression check
+        run: npm run scorecard:check
+
+  self-scorecard:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run ai-os against itself (dry-run)
+        run: node dist/generate.js --dry-run
+
+      - name: Scorecard check (self-hosted regression gate)
+        run: npm run scorecard:check


### PR DESCRIPTION
## Summary

Closes #121

Adds self-hosted scorecard regression check to CI to catch detection quality regressions for the ai-os project's own stack.

## Changes

### `.github/workflows/ai-os-validate.yml`

1. **`validate-full` job** — added `scorecard:check` step after smoke validation (ensures full validation runs also gate on scorecard thresholds)

2. **New `self-scorecard` job** (runs on push/`workflow_dispatch`, not PRs):
   - Checks out, installs deps, builds
   - Runs `node dist/generate.js --dry-run` — runs ai-os against itself
   - Runs `npm run scorecard:check` — fails if KPI metrics are below threshold

## Rationale

Without this gate, detection regressions for the ai-os repo's own TypeScript/Node.js/Vitest stack could silently degrade output quality on every push. The scorecard already tracks `skillContractPassRate`, `startupProtocolCompliance`, and `severityReviewAdoption` metrics with defined thresholds.