### PR TITLE
ci: publish bundle provenance SHA-256 in GitHub releases (#120)

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -108,6 +108,24 @@ jobs:
             echo
             echo "## Commits in this release"
             echo "$COMMITS"
+            echo
+            echo "---"
+            echo
+            echo "## Bundle Provenance"
+            echo
+            echo "SHA-256 checksums for verifying the integrity of shipped bundles:"
+            echo
+            echo "\`\`\`"
+            sha256sum bundle/generate.js dist/server.js
+            echo "\`\`\`"
+            echo
+            echo "To verify after install:"
+            echo "\`\`\`bash"
+            echo "# Verify bundle/generate.js"
+            echo "sha256sum bundle/generate.js"
+            echo "# Verify dist/server.js"
+            echo "sha256sum dist/server.js"
+            echo "\`\`\`"
           } > "$RELEASE_NOTES_FILE"
 
           gh release create "$NEXT_TAG" \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ If your environment blocks `npx github:...`, use the tagged bootstrap script:
 curl -fsSL https://raw.githubusercontent.com/marinvch/ai-os/v0.6.26/bootstrap.sh | bash
 ```
 
+### Verifying bundle integrity
+
+Each [GitHub Release](https://github.com/marinvch/ai-os/releases) includes SHA-256 checksums for `bundle/generate.js` and `dist/server.js`. To verify after install:
+
+```bash
+# Download the checksums from the release notes and verify
+sha256sum bundle/generate.js dist/server.js
+```
+
+Compare the output against the **Bundle Provenance** section in the release notes for the version you installed.
+
 ### Fast bootstrap (paste in any target repo terminal)
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #120

Computes and publishes SHA-256 checksums for the shipped bundles in every GitHub Release, allowing users to verify the integrity of what they ran.

## Changes

### `.github/workflows/release-automation.yml`
- Added a **Bundle Provenance** section to the release notes
- Uses `sha256sum bundle/generate.js dist/server.js` to compute checksums at release time
- Includes a copy-paste verification snippet in the release notes

### `README.md`
- Added **"Verifying bundle integrity"** subsection in the Install section
- Points users to GitHub Releases for checksums
- Shows the `sha256sum` command for post-install verification

## Result

Every release notes page will include:
```
## Bundle Provenance

SHA-256 checksums for verifying the integrity of shipped bundles:

<hash>  bundle/generate.js
<hash>  dist/server.js
```