### PR TITLE
feat: add --json output mode for CI consumers (#118)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,186 @@
+# AI OS CLI Reference
+
+## Actions
+
+| Flag | Action | Description |
+| --- | --- | --- |
+| _(default)_ | `apply` | Generate or refresh all AI OS context files |
+| `--refresh-existing` | `apply` | Refresh mode — update existing files, prune stale |
+| `--update` | `apply` | Same as `--refresh-existing` with version bump message |
+| `--plan` | `plan` | Print onboarding plan, no files written |
+| `--preview` | `preview` | Print plan + "no files written" notice |
+| `--dry-run` | `apply` | Show detected stack as JSON, no files written |
+| `--doctor` | `doctor` | Post-install health validation |
+| `--check-hygiene` | `check-hygiene` | Detect orphaned files, stale lock files, manifest drift |
+| `--check-freshness` | `check-freshness` | Score context freshness vs source files |
+| `--compact-memory` | `compact-memory` | Remove stale memory entries |
+| `--bootstrap` | `bootstrap` | Full generation + auto-install skills |
+| `--uninstall` | _(install.sh flag)_ | Guided removal of all AI OS artifacts |
+
+## Flags
+
+| Flag | Description |
+| --- | --- |
+| `--cwd <path>` | Target repo path (default: `process.cwd()`) |
+| `--profile <minimal\|standard\|full>` | Install density profile |
+| `--dry-run` | Show detected stack as JSON, no writes |
+| `--verbose` / `-v` | Per-file write/skip/prune reasons |
+| `--prune` | Prune stale artifacts without full refresh |
+| `--regenerate-context` | Allow rewrite of curated context files during refresh |
+| `--prune-custom-artifacts` | Also prune non-AI-OS artifacts in managed dirs |
+| `--clean-update` | Aggressive refresh — equivalent to `--refresh-existing` |
+| `--json` | Suppress human output; emit structured JSON to stdout |
+
+## Install Profiles
+
+| Profile | Description |
+| --- | --- |
+| `minimal` | Instructions + MCP wiring only. No agents, skills, recommendations, or session context card. |
+| `standard` | Balanced default — most features on, predefined skills off. |
+| `full` | All integrations — agents, recommendations, session context card, update-check workflow, skills. |
+
+Profiles are persisted to `.github/ai-os/config.json` under `"profile"` and re-applied on subsequent refreshes.
+
+## Common Workflows
+
+```bash
+# Fresh install
+curl -fsSL https://raw.githubusercontent.com/marinvch/ai-os/master/bootstrap.sh | bash
+
+# Refresh existing install
+bash install.sh --refresh-existing
+
+# Check if anything is stale without writing
+node dist/generate.js --check-freshness --cwd /path/to/repo
+
+# Health check after install
+node dist/generate.js --doctor --cwd /path/to/repo
+
+# Hygiene check (orphaned files, manifest drift)
+node dist/generate.js --check-hygiene --cwd /path/to/repo
+
+# CI: emit structured report and exit non-zero on failure
+node dist/generate.js --doctor --json --cwd /path/to/repo
+node dist/generate.js --check-freshness --json --cwd /path/to/repo
+node dist/generate.js --check-hygiene --json --cwd /path/to/repo
+```
+
+## --json Output Mode
+
+Pass `--json` to suppress all human-readable output and emit a single structured JSON object to stdout. Useful for CI integrations, dashboards, and programmatic consumers.
+
+The flag is supported for these actions: `apply`, `doctor`, `check-hygiene`, `check-freshness`.
+
+Exit codes follow the same rules as human mode: critical failures in `doctor` and hygiene issues both exit non-zero.
+
+### apply / bootstrap
+
+```json
+{
+  "action": "apply",
+  "cwd": "/path/to/repo",
+  "mode": "safe",
+  "project": "my-app",
+  "language": "TypeScript",
+  "frameworks": ["Next.js", "React"],
+  "packageManager": "npm",
+  "typescript": true,
+  "profile": null,
+  "mcpToolCount": 29,
+  "written": ["relative/path/to/written-file.md"],
+  "skipped": ["relative/path/to/unchanged-file.md"],
+  "pruned": ["relative/path/to/stale-file.md"],
+  "agents": ["relative/path/to/agent.agent.md"],
+  "preserved": []
+}
+```
+
+For `--bootstrap`, the output includes an additional `bootstrap` field with the bootstrap report.
+
+### doctor
+
+```json
+{
+  "action": "doctor",
+  "cwd": "/path/to/repo",
+  "toolVersion": "0.11.0",
+  "checks": [
+    {
+      "name": "MCP runtime binary present (.ai-os/mcp-server/index.js)",
+      "critical": true,
+      "passed": true,
+      "detail": "/path/to/repo/.ai-os/mcp-server/index.js"
+    }
+  ],
+  "criticalFailures": 0,
+  "warnings": 0
+}
+```
+
+### check-hygiene
+
+```json
+{
+  "action": "check-hygiene",
+  "cwd": "/path/to/repo",
+  "issues": [],
+  "passed": true
+}
+```
+
+### check-freshness
+
+```json
+{
+  "action": "check-freshness",
+  "status": "fresh",
+  "score": 1.0,
+  "snapshotCapturedAt": "2025-01-20T14:00:00.000Z",
+  "lastGenerationAt": "2025-01-20T14:00:00.000Z",
+  "staleArtifacts": [],
+  "changedSourceFiles": [],
+  "recommendations": []
+}
+```
+
+## Dry-run Output Format
+
+With `--dry-run`, AI OS prints the detected stack as JSON and exits:
+
+```json
+{
+  "rootDir": "/path/to/repo",
+  "projectName": "my-app",
+  "primaryLanguage": { "name": "TypeScript", "percentage": 72 },
+  "frameworks": [{ "name": "Next.js", "confidence": 0.95 }],
+  "patterns": {
+    "packageManager": "npm",
+    "hasTypeScript": true,
+    "namingConvention": "kebab-case",
+    "monorepo": false,
+    "srcDirectory": true
+  }
+}
+```
+
+## Bootstrap Output
+
+With `--bootstrap`, AI OS runs full generation then auto-installs stack-relevant skills:
+
+```
+  ╔════════════════════════════════════════╗
+  ║  Bootstrap Plan — my-app               ║
+  ╚════════════════════════════════════════╝
+
+  ✅ [skill]    nextjs       Install: npx -y skills add vercel-labs/agent-skills@nextjs ...
+  📋 [mcp]      context7     Manual: npx -y skills add intellectronica/agent-skills@context7 ...
+```
+
+## Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `AI_OS_ROOT` | Override root directory for MCP server runtime |
+| `AI_OS_MCP_DEBUG=1` | Enable verbose MCP server logging |
+| `CI=true` | Enables CI mode — `--check-freshness` exits non-zero when stale |
+| `GITHUB_ACTIONS=true` | Same as `CI=true` |

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -29,7 +29,7 @@ import type { UpdateStatus } from './updater.js';
 type GenerateMode = 'safe' | 'refresh-existing' | 'update';
 type GenerateAction = 'apply' | 'plan' | 'preview' | 'check-hygiene' | 'doctor' | 'bootstrap' | 'check-freshness' | 'compact-memory';
 
-function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action: GenerateAction; prune: boolean; verbose: boolean; cleanUpdate: boolean; regenerateContext: boolean; pruneCustomArtifacts: boolean; profile: InstallProfile | null } {
+function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action: GenerateAction; prune: boolean; verbose: boolean; cleanUpdate: boolean; regenerateContext: boolean; pruneCustomArtifacts: boolean; profile: InstallProfile | null; json: boolean } {
   const args = process.argv.slice(2);
   let cwd = process.cwd();
   let dryRun = false;
@@ -41,6 +41,7 @@ function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action
   let regenerateContext = false;
   let pruneCustomArtifacts = false;
   let profile: InstallProfile | null = null;
+  let json = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--cwd' && args[i + 1]) {
@@ -94,10 +95,12 @@ function parseArgs(): { cwd: string; dryRun: boolean; mode: GenerateMode; action
       const parsed = parseProfile(raw);
       if (!parsed) throw new Error(`--profile must be one of: minimal, standard, full (got "${raw}")`);
       profile = parsed;
+    } else if (args[i] === '--json') {
+      json = true;
     }
   }
 
-  return { cwd, dryRun, mode, action, prune, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile };
+  return { cwd, dryRun, mode, action, prune, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile, json };
 }
 
 function printBanner(): void {
@@ -505,34 +508,55 @@ function installLocalMcpRuntime(cwd: string, verbose: boolean): void {
 }
 
 async function main(): Promise<void> {
-  printBanner();
-
-  const { cwd, dryRun, mode: rawMode, action, prune: pruneFlag, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile: cliProfile } = parseArgs();
+  const { cwd, dryRun, mode: rawMode, action, prune: pruneFlag, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile: cliProfile, json } = parseArgs();
   let mode: GenerateMode = rawMode;
+
+  // Suppress banner when --json is set
+  if (!json) {
+    printBanner();
+  }
 
   // Enable verbose per-file logging when --verbose / -v is passed
   if (verbose) {
     setVerboseMode(true);
-    console.log('  🔍 Verbose mode enabled — per-file write/skip/prune reasons will be shown.\n');
+    if (!json) console.log('  🔍 Verbose mode enabled — per-file write/skip/prune reasons will be shown.\n');
   }
 
   // ── --check-hygiene action (runs before scan, no generation needed) ────────
   if (action === 'check-hygiene') {
-    runHygieneCheck(cwd);
+    if (json) {
+      const hygieneResult = collectHygieneIssues(cwd);
+      process.stdout.write(JSON.stringify({ action: 'check-hygiene', ...hygieneResult }, null, 2) + '\n');
+      if (hygieneResult.issues.length > 0) process.exit(1);
+    } else {
+      runHygieneCheck(cwd);
+    }
     return;
   }
 
   // ── --doctor action (post-install health validation) ──────────────────────
   if (action === 'doctor') {
     const doctorResult = runDoctor(cwd);
-    const exitCode = printDoctorReport(doctorResult);
-    if (exitCode !== 0) process.exit(exitCode);
+    if (json) {
+      process.stdout.write(JSON.stringify({ action: 'doctor', ...doctorResult }, null, 2) + '\n');
+      if (doctorResult.criticalFailures > 0) process.exit(1);
+    } else {
+      const exitCode = printDoctorReport(doctorResult);
+      if (exitCode !== 0) process.exit(exitCode);
+    }
     return;
   }
 
   // ── --check-freshness action (runs before scan, no generation needed) ──────
   if (action === 'check-freshness') {
-    runFreshnessCheck(cwd);
+    if (json) {
+      const report = computeFreshnessReport(cwd);
+      process.stdout.write(JSON.stringify({ action: 'check-freshness', ...report }, null, 2) + '\n');
+      const isCi = process.env['CI'] === 'true' || process.env['GITHUB_ACTIONS'] === 'true';
+      if (report.status === 'stale' && isCi) process.exit(1);
+    } else {
+      runFreshnessCheck(cwd);
+    }
     return;
   }
 
@@ -550,18 +574,20 @@ async function main(): Promise<void> {
   // Version check — notify if installed artifacts are older than this tool
   const updateStatus = checkUpdateStatus(cwd);
   const installedVersionLabel = updateStatus.installedVersion ?? 'none';
-  console.log(`  🩺 Diagnostics: tool=v${updateStatus.toolVersion}, installed=v${installedVersionLabel}, firstInstall=${updateStatus.isFirstInstall ? 'yes' : 'no'}, updateAvailable=${updateStatus.updateAvailable ? 'yes' : 'no'}`);
+  if (!json) console.log(`  🩺 Diagnostics: tool=v${updateStatus.toolVersion}, installed=v${installedVersionLabel}, firstInstall=${updateStatus.isFirstInstall ? 'yes' : 'no'}, updateAvailable=${updateStatus.updateAvailable ? 'yes' : 'no'}`);
 
   if (mode === 'update') {
-    if (updateStatus.isFirstInstall) {
-      console.log('  ℹ️  No existing AI OS installation found. Running fresh install...');
-    } else if (updateStatus.updateAvailable) {
-      console.log(`  🔄 Updating from v${updateStatus.installedVersion ?? '?'} → v${updateStatus.toolVersion}`);
-    } else {
-      console.log(`  ✅ Already up-to-date (v${updateStatus.toolVersion}). Re-generating to refresh context...`);
+    if (!json) {
+      if (updateStatus.isFirstInstall) {
+        console.log('  ℹ️  No existing AI OS installation found. Running fresh install...');
+      } else if (updateStatus.updateAvailable) {
+        console.log(`  🔄 Updating from v${updateStatus.installedVersion ?? '?'} → v${updateStatus.toolVersion}`);
+      } else {
+        console.log(`  ✅ Already up-to-date (v${updateStatus.toolVersion}). Re-generating to refresh context...`);
+      }
     }
     mode = 'refresh-existing';
-  } else if (mode === 'safe' && !updateStatus.isFirstInstall) {
+  } else if (mode === 'safe' && !updateStatus.isFirstInstall && !json) {
     printUpdateBanner(updateStatus);
   }
 
@@ -570,7 +596,7 @@ async function main(): Promise<void> {
   const isRefresh = mode === 'refresh-existing';
   const preserveContextFiles = isRefresh && !regenerateContext;
 
-  if (isRefresh && preserveContextFiles) {
+  if (isRefresh && preserveContextFiles && !json) {
     console.log('  🔒 Safe refresh: curated context/instruction files will be preserved.');
     console.log('     Pass --regenerate-context to allow full rewrite of those files.');
     console.log('');
@@ -658,7 +684,7 @@ async function main(): Promise<void> {
   // Resolve the effective profile: CLI flag > persisted config > none
   const effectiveProfile = cliProfile ?? config?.profile ?? null;
   if (effectiveProfile) {
-    if (cliProfile) {
+    if (cliProfile && !json) {
       console.log(`\n  🎛️  Applying profile: ${cliProfile}`);
       console.log(describeProfile(cliProfile));
       console.log('');
@@ -685,7 +711,7 @@ async function main(): Promise<void> {
   const workflowFiles = generateWorkflows(cwd, { config: config ?? undefined });
   await deployBundledSkills(cwd, { refreshExisting: mode === 'refresh-existing' });
 
-  console.log(`  🧠 Skills strategy: ${skillsStrategy}`);
+  if (!json) console.log(`  🧠 Skills strategy: ${skillsStrategy}`);
 
   // Phase 3: Recommendations (if enabled in config, default: true)
   const recommendationFiles: string[] = [];
@@ -695,7 +721,7 @@ async function main(): Promise<void> {
     // Skills gap report (stdout only, not written to disk)
     const skillsLockPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'skills-lock.json');
     const gapReport = getSkillsGapReport(stack, skillsLockPath);
-    if (gapReport) console.log(`\n${gapReport}\n`);
+    if (gapReport && !json) console.log(`\n${gapReport}\n`);
   }
 
   // Collect all managed absolute paths and convert to repo-relative forward-slash keys.
@@ -844,8 +870,36 @@ async function main(): Promise<void> {
   installLocalMcpRuntime(cwd, verbose);
 
   // ── Memory maintenance summary (refresh/update mode only) ────────────────
-  if (isRefresh) {
+  if (isRefresh && !json) {
     printMemoryMaintenanceSummary(cwd);
+  }
+
+  if (json) {
+    const mcpToolCount = getMcpToolsForStack(stack).length;
+    const summary = {
+      action: action === 'bootstrap' ? 'bootstrap' : 'apply',
+      cwd,
+      mode,
+      project: stack.projectName,
+      language: stack.primaryLanguage.name,
+      frameworks: stack.frameworks.map(f => f.name),
+      packageManager: stack.patterns.packageManager,
+      typescript: stack.patterns.hasTypeScript,
+      profile: effectiveProfile ?? null,
+      mcpToolCount,
+      written: newFiles.map(f => path.relative(cwd, f).replace(/\\/g, '/')),
+      skipped: existingFiles.map(f => path.relative(cwd, f).replace(/\\/g, '/')),
+      pruned: prunedAbs.map(f => path.relative(cwd, f).replace(/\\/g, '/')),
+      agents: agentFiles.map(f => path.relative(cwd, f).replace(/\\/g, '/')),
+      preserved: preservedAbs.map(f => path.relative(cwd, f).replace(/\\/g, '/')),
+    };
+    if (action === 'bootstrap') {
+      const bootstrapReport = runBootstrap(stack, { dryRun: false });
+      process.stdout.write(JSON.stringify({ ...summary, bootstrap: bootstrapReport }, null, 2) + '\n');
+    } else {
+      process.stdout.write(JSON.stringify(summary, null, 2) + '\n');
+    }
+    return;
   }
 
   printSummary(stack, cwd, newFiles, existingFiles, prunedAbs, agentFiles, preservedAbs, effectiveProfile ?? undefined);
@@ -861,14 +915,14 @@ async function main(): Promise<void> {
   }
 
   // ── Agent-flow setup prompt ──────────────────────────────────────────────
-  // On first install (no prior config) or when agentFlowMode is not explicitly
-  // set, scan for existing agents and print a one-time setup suggestion.
   const agentFlowMode = config?.agentFlowMode;
   const isFirstInstall = updateStatus.isFirstInstall;
-  if (isFirstInstall || agentFlowMode === undefined) {
-    printAgentFlowSetupPrompt(cwd, config?.agentFlowMode ?? null);
+  if (!json) {
+    if (isFirstInstall || agentFlowMode === undefined) {
+      printAgentFlowSetupPrompt(cwd, config?.agentFlowMode ?? null);
+    }
+    printAgentFlowStatus(cwd, config?.agentFlowMode ?? null);
   }
-  printAgentFlowStatus(cwd, config?.agentFlowMode ?? null);
 }
 
 main().catch(err => {
@@ -878,38 +932,38 @@ main().catch(err => {
 
 // ── --check-hygiene ───────────────────────────────────────────────────────────
 
-function runHygieneCheck(cwd: string): void {
-  console.log(`  🧹 Hygiene check: ${cwd}`);
-  console.log('');
+interface HygieneResult {
+  cwd: string;
+  issues: string[];
+  passed: boolean;
+}
+
+function collectHygieneIssues(cwd: string): HygieneResult {
   const issues: string[] = [];
 
-  // Check for legacy .ai-os/context/ artifacts (pre-v0.3.0 paths)
   const legacyContextDir = path.join(cwd, '.ai-os', 'context');
   if (fs.existsSync(legacyContextDir)) {
     const legacyFiles = fs.readdirSync(legacyContextDir);
     if (legacyFiles.length > 0) {
-      issues.push(`  ⚠  Legacy .ai-os/context/ found with ${legacyFiles.length} file(s) — run --refresh-existing to migrate and prune`);
+      issues.push(`Legacy .ai-os/context/ found with ${legacyFiles.length} file(s) — run --refresh-existing to migrate and prune`);
     }
   }
 
-  // Check for leftover .memory.lock files (crash artifact)
   const lockPaths = [
     path.join(cwd, '.github', 'ai-os', 'memory', '.memory.lock'),
     path.join(cwd, '.ai-os', 'memory', '.memory.lock'),
   ];
   for (const lockPath of lockPaths) {
     if (fs.existsSync(lockPath)) {
-      issues.push(`  ⚠  Stale lock file found: ${path.relative(cwd, lockPath)} — safe to delete`);
+      issues.push(`Stale lock file found: ${path.relative(cwd, lockPath)} — safe to delete`);
     }
   }
 
-  // Check for node_modules inside .ai-os/mcp-server/ (Phase F not yet applied)
   const mcpNodeModules = path.join(cwd, '.ai-os', 'mcp-server', 'node_modules');
   if (fs.existsSync(mcpNodeModules)) {
-    issues.push(`  ⚠  node_modules present in .ai-os/mcp-server/ — Phase F (bundle deploy) will eliminate this`);
+    issues.push(`node_modules present in .ai-os/mcp-server/ — Phase F (bundle deploy) will eliminate this`);
   }
 
-  // Check for *.tmp files in ai-os dirs
   const aiOsDirs = [
     path.join(cwd, '.github', 'ai-os'),
     path.join(cwd, '.ai-os'),
@@ -918,26 +972,33 @@ function runHygieneCheck(cwd: string): void {
     if (!fs.existsSync(dir)) continue;
     const tmpFiles = findFilesRecursive(dir, f => f.endsWith('.tmp'));
     for (const f of tmpFiles) {
-      issues.push(`  ⚠  Orphaned temp file: ${path.relative(cwd, f)}`);
+      issues.push(`Orphaned temp file: ${path.relative(cwd, f)}`);
     }
   }
 
-  // Check manifest consistency
   const manifest = readManifest(cwd);
   if (manifest) {
     const missingFiles = manifest.files.filter(f => !fs.existsSync(path.join(cwd, f)));
     if (missingFiles.length > 0) {
-      issues.push(`  ⚠  ${missingFiles.length} manifest entries point to missing files — run --refresh-existing`);
+      issues.push(`${missingFiles.length} manifest entries point to missing files — run --refresh-existing`);
     }
   } else {
-    issues.push(`  ⚠  No manifest.json found — run AI OS generation to create one`);
+    issues.push(`No manifest.json found — run AI OS generation to create one`);
   }
 
-  if (issues.length === 0) {
+  return { cwd, issues, passed: issues.length === 0 };
+}
+
+function runHygieneCheck(cwd: string): void {
+  console.log(`  🧹 Hygiene check: ${cwd}`);
+  console.log('');
+  const { issues, passed } = collectHygieneIssues(cwd);
+
+  if (passed) {
     console.log('  ✅ Hygiene check passed — no orphaned files or dump artifacts found.');
   } else {
     console.log('  Issues found:');
-    for (const issue of issues) console.log(issue);
+    for (const issue of issues) console.log(`  ⚠  ${issue}`);
     console.log('');
     console.log(`  Total issues: ${issues.length}`);
     process.exit(1);


### PR DESCRIPTION
## Summary

Closes #118

Adds `--json` flag to suppress human-readable output and emit a structured JSON report to stdout for CI consumers.

## Changes

### `src/generate.ts`
- Added `json: boolean` to `parseArgs()` return type
- `--json` flag parsed and propagated through all action handlers
- `printBanner()` suppressed when `--json` is set
- **`doctor`**: emits `DoctorResult` as JSON, exits non-zero on critical failures
- **`check-hygiene`**: refactored `runHygieneCheck` into `collectHygieneIssues()` that returns structured `HygieneResult`; JSON path uses that function; human path delegates to it too
- **`check-freshness`**: emits `FreshnessReport` as JSON
- **`apply` / `bootstrap`**: emits summary object with `written`, `skipped`, `pruned`, `agents`, `preserved` file lists plus stack info and MCP tool count
- Human-mode console output (scanning header, diagnostics, skills strategy, profile banner, agent-flow prompts, memory maintenance) suppressed when `--json` is set

### `docs/cli.md` (new)
- Full CLI reference: flags, actions, profiles, workflows
- `--json` output schemas for all four supported actions: `apply`, `doctor`, `check-hygiene`, `check-freshness`
- Dry-run output format, bootstrap output format, env vars

## JSON Schemas

### apply
```json
{ "action": "apply", "cwd": "...", "mode": "safe", "project": "my-app", "language": "TypeScript", "frameworks": [...], "packageManager": "npm", "typescript": true, "profile": null, "mcpToolCount": 29, "written": [...], "skipped": [...], "pruned": [...], "agents": [...], "preserved": [...] }
```

### doctor
```json
{ "action": "doctor", "cwd": "...", "toolVersion": "0.11.0", "checks": [{ "name": "...", "critical": true, "passed": true, "detail": "..." }], "criticalFailures": 0, "warnings": 0 }
```

### check-hygiene
```json
{ "action": "check-hygiene", "cwd": "...", "issues": [], "passed": true }
```

### check-freshness
```json
{ "action": "check-freshness", "status": "fresh", "score": 1.0, "staleArtifacts": [], "changedSourceFiles": [], "recommendations": [] }
```

## Exit Codes

Unchanged from human mode:
- `doctor`: exits 1 when `criticalFailures > 0`
- `check-hygiene`: exits 1 when `issues.length > 0`
- `check-freshness`: exits 1 when `status === "stale"` in CI environment