### PR TITLE
feat: add examples/ reference fixture repos with snapshot tests (#124)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# AI OS Example Fixtures
+
+These directories are reference target repos used as regression fixtures. They exist to verify stack detection and generation output for common stack combinations.
+
+| Directory | Stack |
+| --- | --- |
+| `nextjs-trpc-prisma/` | Next.js + tRPC + Prisma (TypeScript) |
+| `python-fastapi/` | Python + FastAPI |
+| `go-service/` | Go + Gin |
+
+Each fixture is used by `src/tests/examples.test.ts` which runs AI OS stack detection and key generators against the fixture and snapshot-tests the output.
+
+To regenerate snapshots after intentional changes:
+
+```bash
+npm test -- --update-snapshots
+```

--- a/examples/go-service/go.mod
+++ b/examples/go-service/go.mod
@@ -1,0 +1,7 @@
+module github.com/example/go-service
+
+go 1.21
+
+require (
+	github.com/gin-gonic/gin v1.9.1
+)

--- a/examples/go-service/main.go
+++ b/examples/go-service/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+	r.Run()
+}

--- a/examples/nextjs-trpc-prisma/package.json
+++ b/examples/nextjs-trpc-prisma/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "nextjs-trpc-prisma-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "@trpc/server": "^10.0.0",
+    "@trpc/client": "^10.0.0",
+    "@trpc/react-query": "^10.0.0",
+    "@prisma/client": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "prisma": "^5.0.0"
+  }
+}

--- a/examples/nextjs-trpc-prisma/prisma/schema.prisma
+++ b/examples/nextjs-trpc-prisma/prisma/schema.prisma
@@ -1,0 +1,15 @@
+// schema/schema.prisma
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+  name  String?
+}

--- a/examples/nextjs-trpc-prisma/src/server/trpc.ts
+++ b/examples/nextjs-trpc-prisma/src/server/trpc.ts
@@ -1,0 +1,6 @@
+// src/server/trpc.ts
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+export const router = t.router;
+export const publicProcedure = t.procedure;

--- a/examples/nextjs-trpc-prisma/tsconfig.json
+++ b/examples/nextjs-trpc-prisma/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "es2017"],
+    "strict": true,
+    "moduleResolution": "bundler",
+    "jsx": "preserve"
+  }
+}

--- a/examples/python-fastapi/main.py
+++ b/examples/python-fastapi/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Example API")
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/examples/python-fastapi/requirements.txt
+++ b/examples/python-fastapi/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.104.0
+uvicorn[standard]==0.24.0
+pydantic==2.4.0
+sqlalchemy==2.0.23
+alembic==1.12.1

--- a/src/tests/__snapshots__/examples.test.ts.snap
+++ b/src/tests/__snapshots__/examples.test.ts.snap
@@ -1,0 +1,34 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`examples/go-service — stack detection > stack shape matches snapshot 1`] = `
+{
+  "frameworks": [
+    "Gin",
+  ],
+  "packageManager": "go",
+  "primaryLanguage": "Go",
+}
+`;
+
+exports[`examples/nextjs-trpc-prisma — stack detection > stack shape matches snapshot 1`] = `
+{
+  "frameworks": [
+    "Next.js",
+    "Prisma",
+    "tRPC",
+  ],
+  "hasTypeScript": true,
+  "packageManager": "unknown",
+  "primaryLanguage": "JSON",
+}
+`;
+
+exports[`examples/python-fastapi — stack detection > stack shape matches snapshot 1`] = `
+{
+  "frameworks": [
+    "FastAPI",
+  ],
+  "packageManager": "unknown",
+  "primaryLanguage": "Python",
+}
+`;

--- a/src/tests/examples.test.ts
+++ b/src/tests/examples.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Examples fixture regression tests
+ *
+ * Runs AI OS stack detection and key generators against the three reference
+ * fixture repos in examples/ and snapshot-tests the output. This doubles as
+ * living documentation (the fixtures show what AI OS produces for common stacks)
+ * and as a regression bedrock for stack detection + generation output.
+ *
+ * Fixtures:
+ *  - examples/nextjs-trpc-prisma  → Next.js + tRPC + Prisma (TypeScript)
+ *  - examples/python-fastapi      → Python + FastAPI
+ *  - examples/go-service          → Go + Gin
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { analyze } from '../analyze.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXAMPLES_DIR = path.resolve(__dirname, '..', '..', 'examples');
+
+// ---------------------------------------------------------------------------
+// Helper: copy a fixture into a temp dir so generators can write safely
+// ---------------------------------------------------------------------------
+function copyFixture(fixtureName: string): string {
+  const src = path.join(EXAMPLES_DIR, fixtureName);
+  const dest = path.join(os.tmpdir(), `ai-os-fixture-${fixtureName}-${Date.now()}`);
+  fs.cpSync(src, dest, { recursive: true });
+  return dest;
+}
+
+// ---------------------------------------------------------------------------
+// Next.js + tRPC + Prisma
+// ---------------------------------------------------------------------------
+describe('examples/nextjs-trpc-prisma — stack detection', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = copyFixture('nextjs-trpc-prisma');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects TypeScript presence', () => {
+    const stack = analyze(tmpDir);
+    expect(stack.patterns.hasTypeScript).toBe(true);
+    // Primary language may be JSON or TypeScript depending on file count, but TS must be present
+    const langs = stack.languages.map(l => l.name);
+    expect(langs).toContain('TypeScript');
+  });
+
+  it('detects Next.js framework', () => {
+    const stack = analyze(tmpDir);
+    const fw = stack.frameworks.map(f => f.name.toLowerCase());
+    expect(fw.some(n => n.includes('next'))).toBe(true);
+  });
+
+  it('detects tRPC dependency', () => {
+    const stack = analyze(tmpDir);
+    const deps = stack.allDependencies.map(d => d.toLowerCase());
+    expect(deps.some(d => d.includes('trpc'))).toBe(true);
+  });
+
+  it('detects Prisma dependency', () => {
+    const stack = analyze(tmpDir);
+    const deps = stack.allDependencies.map(d => d.toLowerCase());
+    expect(deps.some(d => d.includes('prisma'))).toBe(true);
+  });
+
+  it('generates instructions file containing Next.js content', async () => {
+    const { generateInstructions } = await import('../generators/instructions.js');
+    const stack = analyze(tmpDir);
+    const githubDir = path.join(tmpDir, '.github');
+    fs.mkdirSync(githubDir, { recursive: true });
+
+    generateInstructions(stack, tmpDir, { refreshExisting: false });
+
+    const instructionsPath = path.join(githubDir, 'copilot-instructions.md');
+    expect(fs.existsSync(instructionsPath)).toBe(true);
+    const content = fs.readFileSync(instructionsPath, 'utf-8');
+    expect(content.length).toBeGreaterThan(100);
+    // Should contain Next.js-specific content
+    expect(content.toLowerCase()).toMatch(/next/);
+  });
+
+  it('stack shape matches snapshot', () => {
+    const stack = analyze(tmpDir);
+    expect({
+      primaryLanguage: stack.primaryLanguage.name,
+      hasTypeScript: stack.patterns.hasTypeScript,
+      packageManager: stack.patterns.packageManager,
+      frameworks: stack.frameworks.map(f => f.name).sort(),
+    }).toMatchSnapshot();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Python FastAPI
+// ---------------------------------------------------------------------------
+describe('examples/python-fastapi — stack detection', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = copyFixture('python-fastapi');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects Python as primary language', () => {
+    const stack = analyze(tmpDir);
+    expect(stack.primaryLanguage.name).toBe('Python');
+  });
+
+  it('detects FastAPI dependency', () => {
+    const stack = analyze(tmpDir);
+    const deps = stack.allDependencies.map(d => d.toLowerCase());
+    expect(deps.some(d => d.includes('fastapi'))).toBe(true);
+  });
+
+  it('generates instructions file', async () => {
+    const { generateInstructions } = await import('../generators/instructions.js');
+    const stack = analyze(tmpDir);
+    const githubDir = path.join(tmpDir, '.github');
+    fs.mkdirSync(githubDir, { recursive: true });
+
+    generateInstructions(stack, tmpDir, { refreshExisting: false });
+
+    const instructionsPath = path.join(githubDir, 'copilot-instructions.md');
+    expect(fs.existsSync(instructionsPath)).toBe(true);
+    const content = fs.readFileSync(instructionsPath, 'utf-8');
+    expect(content.length).toBeGreaterThan(100);
+  });
+
+  it('stack shape matches snapshot', () => {
+    const stack = analyze(tmpDir);
+    expect({
+      primaryLanguage: stack.primaryLanguage.name,
+      packageManager: stack.patterns.packageManager,
+      frameworks: stack.frameworks.map(f => f.name).sort(),
+    }).toMatchSnapshot();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Go service
+// ---------------------------------------------------------------------------
+describe('examples/go-service — stack detection', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = copyFixture('go-service');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects Go as primary language', () => {
+    const stack = analyze(tmpDir);
+    expect(stack.primaryLanguage.name).toBe('Go');
+  });
+
+  it('generates instructions file', async () => {
+    const { generateInstructions } = await import('../generators/instructions.js');
+    const stack = analyze(tmpDir);
+    const githubDir = path.join(tmpDir, '.github');
+    fs.mkdirSync(githubDir, { recursive: true });
+
+    generateInstructions(stack, tmpDir, { refreshExisting: false });
+
+    const instructionsPath = path.join(githubDir, 'copilot-instructions.md');
+    expect(fs.existsSync(instructionsPath)).toBe(true);
+    const content = fs.readFileSync(instructionsPath, 'utf-8');
+    expect(content.length).toBeGreaterThan(100);
+  });
+
+  it('stack shape matches snapshot', () => {
+    const stack = analyze(tmpDir);
+    expect({
+      primaryLanguage: stack.primaryLanguage.name,
+      packageManager: stack.patterns.packageManager,
+      frameworks: stack.frameworks.map(f => f.name).sort(),
+    }).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Closes #124

## Changes

- Added `examples/` directory with three reference fixture repos:
  - `examples/nextjs-trpc-prisma/` — Next.js + tRPC + Prisma (TypeScript)
  - `examples/python-fastapi/` — Python + FastAPI
  - `examples/go-service/` — Go + Gin
- Added `examples/README.md` describing the fixture purpose and snapshot regeneration
- Added `src/tests/examples.test.ts` with 13 snapshot + property tests covering:
  - Stack detection (primary language, framework detection, dependency detection)
  - Instructions generation (file creation and content validation)
  - Snapshot tests for stack shape (stored in `__snapshots__/examples.test.ts.snap`)

## Test results

```
Tests  13 passed (13)
```

All 204 tests pass after adding this suite.