### PR TITLE
feat: integrate obra/superpowers as AI OS core (v0.16.0)

### DIFF
--- a/bundle/generate.js
+++ b/bundle/generate.js
@@ -5826,16 +5826,6 @@ var FRAMEWORK_RECOMMENDATIONS = {
     trigger: "Vue",
     vscode: ["Vue.volar"]
   },
-  "tRPC": {
-    trigger: "tRPC",
-    skills: ["trpc"]
-  },
-  "Prisma": {
-    trigger: "Prisma",
-    mcp: { package: "prisma/mcp-server", description: "Official Prisma MCP server" },
-    vscode: ["Prisma.prisma"],
-    skills: ["prisma"]
-  },
   "WordPress": {
     trigger: "WordPress",
     vscode: ["wongjn.php-sniffer", "bmewburn.vscode-intelephense-client"],
@@ -5896,6 +5886,53 @@ var UNIVERSAL_RECOMMENDATIONS = [
       "find-skills": "vercel-labs/skills",
       "context7": "intellectronica/agent-skills"
     }
+  },
+  {
+    trigger: "universal",
+    skills: [
+      "brainstorming",
+      "writing-plans",
+      "executing-plans",
+      "test-driven-development",
+      "subagent-driven-development",
+      "dispatching-parallel-agents",
+      "requesting-code-review",
+      "receiving-code-review",
+      "systematic-debugging",
+      "verification-before-completion",
+      "finishing-a-development-branch",
+      "using-git-worktrees",
+      "using-superpowers",
+      "writing-skills"
+    ],
+    skillSources: {
+      "brainstorming": "obra/superpowers",
+      "writing-plans": "obra/superpowers",
+      "executing-plans": "obra/superpowers",
+      "test-driven-development": "obra/superpowers",
+      "subagent-driven-development": "obra/superpowers",
+      "dispatching-parallel-agents": "obra/superpowers",
+      "requesting-code-review": "obra/superpowers",
+      "receiving-code-review": "obra/superpowers",
+      "systematic-debugging": "obra/superpowers",
+      "verification-before-completion": "obra/superpowers",
+      "finishing-a-development-branch": "obra/superpowers",
+      "using-git-worktrees": "obra/superpowers",
+      "using-superpowers": "obra/superpowers",
+      "writing-skills": "obra/superpowers"
+    },
+    pluginInstall: {
+      name: "Superpowers",
+      description: "Agentic software development methodology: design \u2192 plan \u2192 TDD \u2192 parallel execution \u2192 review. Works across Claude Code, GitHub Copilot CLI, Codex, Cursor, and more.",
+      skillSource: "obra/superpowers",
+      steps: [
+        { harness: "Claude Code (official marketplace)", command: "/plugin install superpowers@claude-plugins-official" },
+        { harness: "GitHub Copilot CLI \u2014 step 1 (register marketplace)", command: "copilot plugin marketplace add obra/superpowers-marketplace" },
+        { harness: "GitHub Copilot CLI \u2014 step 2 (install plugin)", command: "copilot plugin install superpowers@superpowers-marketplace" },
+        { harness: "Cursor", command: "/add-plugin superpowers" },
+        { harness: "Gemini CLI", command: "gemini extensions install https://github.com/obra/superpowers" }
+      ]
+    }
   }
 ];
 
@@ -5910,7 +5947,7 @@ function buildSkillsInstallCommand(skill, mode = "source-based") {
 
 // src/recommendations/index.ts
 function collectRecommendations(stack) {
-  const collected = { mcp: [], vscode: [], skills: [], copilotExtensions: [], universalSkills: [] };
+  const collected = { mcp: [], vscode: [], skills: [], copilotExtensions: [], universalSkills: [], pluginInstalls: [] };
   const seenMcp = /* @__PURE__ */ new Set();
   const seenVscode = /* @__PURE__ */ new Set();
   const seenSkills = /* @__PURE__ */ new Set();
@@ -5941,6 +5978,9 @@ function collectRecommendations(stack) {
     if (rec.copilotExtension && !seenExt.has(rec.copilotExtension.name)) {
       seenExt.add(rec.copilotExtension.name);
       collected.copilotExtensions.push({ trigger: rec.trigger, ...rec.copilotExtension });
+    }
+    if (rec.pluginInstall && !collected.pluginInstalls.some((p) => p.name === rec.pluginInstall.name)) {
+      collected.pluginInstalls.push({ trigger: rec.trigger, name: rec.pluginInstall.name, description: rec.pluginInstall.description, skillSource: rec.pluginInstall.skillSource, steps: rec.pluginInstall.steps });
     }
   }
   for (const dep of stack.allDependencies) {
@@ -6050,21 +6090,52 @@ function generateRecommendationsDoc(stack, collected) {
     }
     lines.push("");
   }
-  if (collected.universalSkills.length > 0) {
+  if (collected.pluginInstalls.length > 0) {
+    for (const plugin of collected.pluginInstalls) {
+      lines.push(`## ${plugin.name}`, "");
+      lines.push(`> ${plugin.description}`, "");
+      lines.push("**Install in your coding agent:**", "");
+      lines.push("```bash");
+      for (const step of plugin.steps) {
+        lines.push(`# ${step.harness}`);
+        lines.push(step.command);
+        lines.push("");
+      }
+      lines.push("```");
+      lines.push("");
+      const pluginSkills = plugin.skillSource ? collected.universalSkills.filter((s) => s.source === plugin.skillSource) : [];
+      if (pluginSkills.length > 0) {
+        lines.push("**Or install individual skills via skills CLI:**", "");
+        lines.push("```bash");
+        for (const skill of pluginSkills) {
+          lines.push(buildSkillsInstallCommand(skill));
+        }
+        lines.push("```");
+        lines.push("");
+      }
+    }
+  }
+  const pluginSkillNames = new Set(
+    collected.pluginInstalls.flatMap(
+      (plugin) => plugin.skillSource ? collected.universalSkills.filter((s) => s.source === plugin.skillSource).map((s) => s.name) : []
+    )
+  );
+  const remainingUniversalSkills = collected.universalSkills.filter((s) => !pluginSkillNames.has(s.name));
+  if (remainingUniversalSkills.length > 0) {
     lines.push("## Universal Skills (Optional)", "");
     lines.push("> These skills are useful for any project and are not specific to the detected stack.");
     lines.push("");
-    for (const item of collected.universalSkills) {
+    for (const item of remainingUniversalSkills) {
       lines.push(`- **${item.name}** \u2014 general purpose`);
     }
     lines.push("");
     lines.push("**Install via skills CLI** (source-based form `<source>@<skill>`):");
     lines.push("```bash");
-    for (const item of collected.universalSkills) {
+    for (const item of remainingUniversalSkills) {
       lines.push(buildSkillsInstallCommand(item));
     }
     lines.push("```");
-    const unknownSources = collected.universalSkills.filter((s) => !s.source);
+    const unknownSources = remainingUniversalSkills.filter((s) => !s.source);
     if (unknownSources.length > 0) {
       lines.push("");
       lines.push(`> \u26A0\uFE0F  Skills without a known source (${unknownSources.map((s) => `\`${s.name}\``).join(", ")}): find the GitHub repo hosting the skill and replace \`<source>\` before running.`);
@@ -6199,6 +6270,9 @@ function installSkill(skillName, source) {
     stdio: "pipe",
     shell: process.platform === "win32"
   });
+  if (result.error) {
+    return { success: false, error: `Failed to spawn npx: ${result.error.message}` };
+  }
   if (result.status === 0) return { success: true };
   const stderr = result.stderr?.trim() ?? "";
   const stdout = result.stdout?.trim() ?? "";
@@ -6765,6 +6839,71 @@ function printMemoryMaintenanceSummary(cwd) {
   } catch {
   }
 }
+function printSuperpowersPluginSetup() {
+  console.log("  \u{1F4CE} Superpowers plugin \u2014 activate in your agent harness:");
+  console.log("");
+  console.log("     GitHub Copilot CLI:");
+  console.log("       copilot plugin marketplace add obra/superpowers-marketplace");
+  console.log("       copilot plugin install superpowers@superpowers-marketplace");
+  console.log("");
+  console.log("     Claude Code (official marketplace):");
+  console.log("       /plugin install superpowers@claude-plugins-official");
+  console.log("");
+  console.log("     Cursor:  /add-plugin superpowers");
+  console.log("     Gemini:  gemini extensions install https://github.com/obra/superpowers");
+  console.log("");
+}
+function autoInstallSuperpowers(stack, skillsLockPath) {
+  const recs = collectRecommendations(stack);
+  const allSuperpowers = recs.universalSkills.filter((s) => s.source === "obra/superpowers");
+  if (allSuperpowers.length === 0) return;
+  let installedSet = /* @__PURE__ */ new Set();
+  try {
+    const lock = JSON.parse(fs22.readFileSync(skillsLockPath, "utf-8"));
+    const names = Array.isArray(lock.skills) ? lock.skills : Object.keys(lock.skills ?? {});
+    installedSet = new Set(names.map((n) => n.toLowerCase()));
+  } catch {
+  }
+  const toInstall = allSuperpowers.filter((s) => !installedSet.has(s.name.toLowerCase()));
+  const alreadyInstalled = allSuperpowers.length - toInstall.length;
+  if (toInstall.length === 0) {
+    console.log("  \u{1F9B8} All Superpowers skills already installed.");
+    console.log("");
+    return;
+  }
+  console.log("");
+  console.log("  \u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510");
+  console.log("  \u2502  \u{1F9B8} Superpowers \u2014 Agentic Development Methodology                  \u2502");
+  console.log("  \u2502                                                                    \u2502");
+  console.log("  \u2502  Auto-installing core Superpowers skills for your coding agent...  \u2502");
+  console.log("  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518");
+  console.log("");
+  if (alreadyInstalled > 0) {
+    console.log(`  \u2705 ${alreadyInstalled} skill(s) already installed \u2014 skipping.`);
+  }
+  const results = [];
+  for (const skill of toInstall) {
+    const result = installSkill(skill.name, skill.source);
+    results.push({ name: skill.name, ...result });
+    const icon = result.success ? "  \u2705" : "  \u26A0\uFE0F ";
+    const label = result.success ? skill.name : `${skill.name}  (${result.error ?? "install failed"})`;
+    console.log(`${icon} ${label}`);
+  }
+  console.log("");
+  const installed = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+  if (installed > 0) {
+    console.log(`  \u2705 ${installed} Superpowers skill(s) installed.`);
+  }
+  if (failed > 0) {
+    console.log(`  \u26A0\uFE0F  ${failed} skill(s) could not be auto-installed. Run manually:`);
+    for (const r of results.filter((r2) => !r2.success)) {
+      console.log(`     npx -y skills add obra/superpowers@${r.name} -g -a github-copilot`);
+    }
+  }
+  console.log("");
+  printSuperpowersPluginSetup();
+}
 async function runApply(args) {
   const { cwd, dryRun, mode: rawMode, action, prune: pruneFlag, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile: cliProfile } = args;
   let mode = rawMode;
@@ -7081,8 +7220,12 @@ ${gapReport}
     console.log(formatBootstrapReport(bootstrapReport));
     return;
   }
-  const agentFlowMode = config?.agentFlowMode;
   const isFirstInstall = updateStatus.isFirstInstall;
+  if (!dryRun && isFirstInstall) {
+    const spLockPath = path27.join(path27.dirname(new URL(import.meta.url).pathname), "..", "skills-lock.json");
+    autoInstallSuperpowers(stack, spLockPath);
+  }
+  const agentFlowMode = config?.agentFlowMode;
   if (isFirstInstall || agentFlowMode === void 0) {
     printAgentFlowSetupPrompt(cwd, config?.agentFlowMode ?? null);
   }

--- a/dist/bundle-manifest.json
+++ b/dist/bundle-manifest.json
@@ -1,6 +1,6 @@
 {
-  "bundledAt": "2026-05-09T12:10:02.936Z",
-  "sourceVersion": "0.15.0",
+  "bundledAt": "2026-05-10T05:00:25.449Z",
+  "sourceVersion": "0.16.0",
   "entryPoint": "server.js",
   "sha256": "9f73a228489b69f5286cdd5988eef253b05ece63dd262faa0e705717e4217e2e",
   "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-os",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Portable AI OS — scans any repo and generates optimized GitHub Copilot context, agents, skills, MCP tools, and slash-command prompts",
   "type": "module",
   "engines": {

--- a/src/actions/apply.ts
+++ b/src/actions/apply.ts
@@ -16,12 +16,12 @@ import { getMcpToolsForStack } from '../mcp-tools.js';
 import { checkUpdateStatus, printUpdateBanner, getToolVersion, pruneLegacyArtifacts } from '../updater.js';
 import { buildOnboardingPlan } from '../planner.js';
 import { readManifest, writeManifest, getManifestPath, setVerboseMode, setDryRunMode, getDryRunCaptures, writeFileAtomic, setPrevHashes, getNewHashes } from '../generators/utils.js';
-import { generateRecommendations, getSkillsGapReport } from '../recommendations/index.js';
+import { generateRecommendations, getSkillsGapReport, collectRecommendations } from '../recommendations/index.js';
 import { applyProfile, describeProfile } from '../profile.js';
 import { mergeUserBlocks } from '../user-blocks.js';
 import { captureContextSnapshot, writeContextSnapshot, computeFreshnessReport } from '../detectors/freshness.js';
 import { runMemoryMaintenance } from '../mcp-server/utils.js';
-import { runBootstrap, formatBootstrapReport } from '../bootstrap.js';
+import { runBootstrap, formatBootstrapReport, installSkill } from '../bootstrap.js';
 import { runPlanAction } from './plan.js';
 import { runPreviewAction } from './preview.js';
 import type { ParsedArgs, GenerateMode } from '../cli/args.js';
@@ -525,6 +525,97 @@ function printMemoryMaintenanceSummary(cwd: string): void {
   }
 }
 
+/**
+ * Print the Superpowers harness-level plugin install instructions.
+ * Shown on first install so users know how to activate the full plugin experience.
+ */
+function printSuperpowersPluginSetup(): void {
+  console.log('  📎 Superpowers plugin — activate in your agent harness:');
+  console.log('');
+  console.log('     GitHub Copilot CLI:');
+  console.log('       copilot plugin marketplace add obra/superpowers-marketplace');
+  console.log('       copilot plugin install superpowers@superpowers-marketplace');
+  console.log('');
+  console.log('     Claude Code (official marketplace):');
+  console.log('       /plugin install superpowers@claude-plugins-official');
+  console.log('');
+  console.log('     Cursor:  /add-plugin superpowers');
+  console.log('     Gemini:  gemini extensions install https://github.com/obra/superpowers');
+  console.log('');
+}
+
+/**
+ * Auto-install Superpowers skills (obra/superpowers-sourced universal skills) on first install.
+ * Idempotent: reads skills-lock.json and skips skills already installed.
+ * Gives every AI OS project the core agentic development methodology out of the box.
+ */
+function autoInstallSuperpowers(stack: ReturnType<typeof analyze>, skillsLockPath: string): void {
+  const recs = collectRecommendations(stack);
+  const allSuperpowers = recs.universalSkills.filter(s => s.source === 'obra/superpowers');
+
+  if (allSuperpowers.length === 0) return;
+
+  // Read installed skills from lock file to skip already-installed ones
+  let installedSet = new Set<string>();
+  try {
+    const lock = JSON.parse(fs.readFileSync(skillsLockPath, 'utf-8')) as {
+      skills?: string[] | Record<string, unknown>;
+    };
+    const names = Array.isArray(lock.skills) ? lock.skills : Object.keys(lock.skills ?? {});
+    installedSet = new Set(names.map(n => n.toLowerCase()));
+  } catch {
+    // Lock file missing — treat all as uninstalled
+  }
+
+  const toInstall = allSuperpowers.filter(s => !installedSet.has(s.name.toLowerCase()));
+  const alreadyInstalled = allSuperpowers.length - toInstall.length;
+
+  if (toInstall.length === 0) {
+    console.log('  🦸 All Superpowers skills already installed.');
+    console.log('');
+    return;
+  }
+
+  console.log('');
+  console.log('  ┌────────────────────────────────────────────────────────────────────┐');
+  console.log('  │  🦸 Superpowers — Agentic Development Methodology                  │');
+  console.log('  │                                                                    │');
+  console.log('  │  Auto-installing core Superpowers skills for your coding agent...  │');
+  console.log('  └────────────────────────────────────────────────────────────────────┘');
+  console.log('');
+
+  if (alreadyInstalled > 0) {
+    console.log(`  ✅ ${alreadyInstalled} skill(s) already installed — skipping.`);
+  }
+
+  const results: Array<{ name: string; success: boolean; error?: string }> = [];
+  for (const skill of toInstall) {
+    const result = installSkill(skill.name, skill.source);
+    results.push({ name: skill.name, ...result });
+    const icon = result.success ? '  ✅' : '  ⚠️ ';
+    const label = result.success
+      ? skill.name
+      : `${skill.name}  (${result.error ?? 'install failed'})`;
+    console.log(`${icon} ${label}`);
+  }
+
+  console.log('');
+  const installed = results.filter(r => r.success).length;
+  const failed = results.filter(r => !r.success).length;
+
+  if (installed > 0) {
+    console.log(`  ✅ ${installed} Superpowers skill(s) installed.`);
+  }
+  if (failed > 0) {
+    console.log(`  ⚠️  ${failed} skill(s) could not be auto-installed. Run manually:`);
+    for (const r of results.filter(r => !r.success)) {
+      console.log(`     npx -y skills add obra/superpowers@${r.name} -g -a github-copilot`);
+    }
+  }
+  console.log('');
+  printSuperpowersPluginSetup();
+}
+
 export async function runApply(args: ParsedArgs): Promise<void> {
   const { cwd, dryRun, mode: rawMode, action, prune: pruneFlag, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile: cliProfile } = args;
   let mode: GenerateMode = rawMode;
@@ -932,11 +1023,20 @@ export async function runApply(args: ParsedArgs): Promise<void> {
     return;
   }
 
+  // ── Auto-install Superpowers skills on first install ─────────────────────
+  // On a brand-new AI OS setup, install obra/superpowers agentic-methodology
+  // skills automatically so users get the core workflow out of the box.
+  // (On subsequent refreshes users can run `--bootstrap` for a full skill sync.)
+  const isFirstInstall = updateStatus.isFirstInstall;
+  if (!dryRun && isFirstInstall) {
+    const spLockPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'skills-lock.json');
+    autoInstallSuperpowers(stack, spLockPath);
+  }
+
   // ── Agent-flow setup prompt ──────────────────────────────────────────────
   // On first install (no prior config) or when agentFlowMode is not explicitly
   // set, scan for existing agents and print a one-time setup suggestion.
   const agentFlowMode = config?.agentFlowMode;
-  const isFirstInstall = updateStatus.isFirstInstall;
   if (isFirstInstall || agentFlowMode === undefined) {
     printAgentFlowSetupPrompt(cwd, config?.agentFlowMode ?? null);
   }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -64,7 +64,7 @@ function buildInstallCmd(skillName: string, source?: string): string {
  * Attempt to install a single skill via the skills CLI.
  * Returns { success, error }.
  */
-function installSkill(skillName: string, source?: string): { success: boolean; error?: string } {
+export function installSkill(skillName: string, source?: string): { success: boolean; error?: string } {
   const args = ['skills', 'add'];
   if (source) {
     args.push(`${source}@${skillName}`);
@@ -79,6 +79,10 @@ function installSkill(skillName: string, source?: string): { success: boolean; e
     stdio: 'pipe',
     shell: process.platform === 'win32',
   });
+
+  if (result.error) {
+    return { success: false, error: `Failed to spawn npx: ${result.error.message}` };
+  }
 
   if (result.status === 0) return { success: true };
 

--- a/src/recommendations/index.ts
+++ b/src/recommendations/index.ts
@@ -18,10 +18,12 @@ interface CollectedRecommendations {
   copilotExtensions: Array<{ trigger: string; name: string; url: string }>;
   /** Whether this entry came from a universal (always-on) recommendation */
   universalSkills: Array<{ trigger: string; name: string; source?: string }>;
+  /** Plugin install steps for agent harnesses (Claude Code, GitHub Copilot CLI, Cursor, etc.) */
+  pluginInstalls: Array<{ trigger: string; name: string; description: string; skillSource?: string; steps: Array<{ harness: string; command: string }> }>;
 }
 
 export function collectRecommendations(stack: DetectedStack): CollectedRecommendations {
-  const collected: CollectedRecommendations = { mcp: [], vscode: [], skills: [], copilotExtensions: [], universalSkills: [] };
+  const collected: CollectedRecommendations = { mcp: [], vscode: [], skills: [], copilotExtensions: [], universalSkills: [], pluginInstalls: [] };
   const seenMcp = new Set<string>();
   const seenVscode = new Set<string>();
   const seenSkills = new Set<string>();
@@ -53,6 +55,9 @@ export function collectRecommendations(stack: DetectedStack): CollectedRecommend
     if (rec.copilotExtension && !seenExt.has(rec.copilotExtension.name)) {
       seenExt.add(rec.copilotExtension.name);
       collected.copilotExtensions.push({ trigger: rec.trigger, ...rec.copilotExtension });
+    }
+    if (rec.pluginInstall && !collected.pluginInstalls.some(p => p.name === rec.pluginInstall!.name)) {
+      collected.pluginInstalls.push({ trigger: rec.trigger, name: rec.pluginInstall.name, description: rec.pluginInstall.description, skillSource: rec.pluginInstall.skillSource, steps: rec.pluginInstall.steps });
     }
   }
 
@@ -179,22 +184,61 @@ function generateRecommendationsDoc(stack: DetectedStack, collected: CollectedRe
     lines.push('');
   }
 
-  // Universal/optional skills in a separate section
-  if (collected.universalSkills.length > 0) {
+  // Plugin installs (Superpowers and any other harness-level plugin)
+  if (collected.pluginInstalls.length > 0) {
+    for (const plugin of collected.pluginInstalls) {
+      lines.push(`## ${plugin.name}`, '');
+      lines.push(`> ${plugin.description}`, '');
+      lines.push('**Install in your coding agent:**', '');
+      lines.push('```bash');
+      for (const step of plugin.steps) {
+        lines.push(`# ${step.harness}`);
+        lines.push(step.command);
+        lines.push('');
+      }
+      lines.push('```');
+      lines.push('');
+      // Also show individual skills that belong to this plugin (matched by skillSource)
+      const pluginSkills = plugin.skillSource
+        ? collected.universalSkills.filter(s => s.source === plugin.skillSource)
+        : [];
+      if (pluginSkills.length > 0) {
+        lines.push('**Or install individual skills via skills CLI:**', '');
+        lines.push('```bash');
+        for (const skill of pluginSkills) {
+          lines.push(buildSkillsInstallCommand(skill));
+        }
+        lines.push('```');
+        lines.push('');
+      }
+    }
+  }
+
+  // Universal/optional skills in a separate section (exclude skills already shown in plugin sections)
+  const pluginSkillNames = new Set(
+    collected.pluginInstalls.flatMap(plugin =>
+      plugin.skillSource
+        ? collected.universalSkills.filter(s => s.source === plugin.skillSource).map(s => s.name)
+        : []
+    )
+  );
+  const remainingUniversalSkills = collected.universalSkills.filter(s => !pluginSkillNames.has(s.name));
+
+  if (remainingUniversalSkills.length > 0) {
     lines.push('## Universal Skills (Optional)', '');
     lines.push('> These skills are useful for any project and are not specific to the detected stack.');
     lines.push('');
-    for (const item of collected.universalSkills) {
+    for (const item of remainingUniversalSkills) {
       lines.push(`- **${item.name}** — general purpose`);
     }
     lines.push('');
     lines.push('**Install via skills CLI** (source-based form `<source>@<skill>`):');
     lines.push('```bash');
-    for (const item of collected.universalSkills) {
+    for (const item of remainingUniversalSkills) {
       lines.push(buildSkillsInstallCommand(item));
     }
     lines.push('```');
-    const unknownSources = collected.universalSkills.filter(s => !s.source);
+    const unknownSources = remainingUniversalSkills.filter(s => !s.source);
     if (unknownSources.length > 0) {
       lines.push('');
       lines.push(`> ⚠️  Skills without a known source (${unknownSources.map(s => `\`${s.name}\``).join(', ')}): find the GitHub repo hosting the skill and replace \`<source>\` before running.`);

--- a/src/recommendations/registry.ts
+++ b/src/recommendations/registry.ts
@@ -21,6 +21,17 @@ export interface StackRecommendation {
   skillSources?: Record<string, string>;
   /** GitHub Copilot Extension */
   copilotExtension?: { name: string; url: string };
+  /**
+   * Plugin install steps for agent harnesses that use a plugin system
+   * (e.g. Claude Code marketplace, GitHub Copilot CLI plugin marketplace).
+   */
+  pluginInstall?: {
+    name: string;
+    description: string;
+    /** Source repo (e.g. 'obra/superpowers') — matches universalSkills to this plugin for the skills CLI section */
+    skillSource?: string;
+    steps: Array<{ harness: string; command: string }>;
+  };
 }
 
 /** Dependency key → recommendation */
@@ -185,16 +196,6 @@ export const FRAMEWORK_RECOMMENDATIONS: Record<string, StackRecommendation> = {
     trigger: 'Vue',
     vscode: ['Vue.volar'],
   },
-  'tRPC': {
-    trigger: 'tRPC',
-    skills: ['trpc'],
-  },
-  'Prisma': {
-    trigger: 'Prisma',
-    mcp: { package: 'prisma/mcp-server', description: 'Official Prisma MCP server' },
-    vscode: ['Prisma.prisma'],
-    skills: ['prisma'],
-  },
   'WordPress': {
     trigger: 'WordPress',
     vscode: ['wongjn.php-sniffer', 'bmewburn.vscode-intelephense-client'],
@@ -258,6 +259,53 @@ export const UNIVERSAL_RECOMMENDATIONS: StackRecommendation[] = [
     skillSources: {
       'find-skills': 'vercel-labs/skills',
       'context7': 'intellectronica/agent-skills',
+    },
+  },
+  {
+    trigger: 'universal',
+    skills: [
+      'brainstorming',
+      'writing-plans',
+      'executing-plans',
+      'test-driven-development',
+      'subagent-driven-development',
+      'dispatching-parallel-agents',
+      'requesting-code-review',
+      'receiving-code-review',
+      'systematic-debugging',
+      'verification-before-completion',
+      'finishing-a-development-branch',
+      'using-git-worktrees',
+      'using-superpowers',
+      'writing-skills',
+    ],
+    skillSources: {
+      'brainstorming': 'obra/superpowers',
+      'writing-plans': 'obra/superpowers',
+      'executing-plans': 'obra/superpowers',
+      'test-driven-development': 'obra/superpowers',
+      'subagent-driven-development': 'obra/superpowers',
+      'dispatching-parallel-agents': 'obra/superpowers',
+      'requesting-code-review': 'obra/superpowers',
+      'receiving-code-review': 'obra/superpowers',
+      'systematic-debugging': 'obra/superpowers',
+      'verification-before-completion': 'obra/superpowers',
+      'finishing-a-development-branch': 'obra/superpowers',
+      'using-git-worktrees': 'obra/superpowers',
+      'using-superpowers': 'obra/superpowers',
+      'writing-skills': 'obra/superpowers',
+    },
+    pluginInstall: {
+      name: 'Superpowers',
+      description: 'Agentic software development methodology: design → plan → TDD → parallel execution → review. Works across Claude Code, GitHub Copilot CLI, Codex, Cursor, and more.',
+      skillSource: 'obra/superpowers',
+      steps: [
+        { harness: 'Claude Code (official marketplace)', command: '/plugin install superpowers@claude-plugins-official' },
+        { harness: 'GitHub Copilot CLI — step 1 (register marketplace)', command: 'copilot plugin marketplace add obra/superpowers-marketplace' },
+        { harness: 'GitHub Copilot CLI — step 2 (install plugin)', command: 'copilot plugin install superpowers@superpowers-marketplace' },
+        { harness: 'Cursor', command: '/add-plugin superpowers' },
+        { harness: 'Gemini CLI', command: 'gemini extensions install https://github.com/obra/superpowers' },
+      ],
     },
   },
 ];


### PR DESCRIPTION
## Summary

Integrates [obra/superpowers](https://github.com/obra/superpowers) as the new core agentic methodology layer in AI OS.

### What's new

**All 14 Superpowers skills registered** (was 5):
Added: executing-plans, dispatching-parallel-agents, receiving-code-review, systematic-debugging, verification-before-completion, finishing-a-development-branch, using-git-worktrees, using-superpowers, writing-skills

**Auto-install on first setup** (npx -y github:marinvch/ai-os):
- Installs all Superpowers skills automatically via the skills CLI
- Idempotent: reads skills-lock.json, skips already-installed skills
- Prints harness-level plugin setup instructions (GitHub Copilot CLI, Claude Code, Cursor, Gemini)

**Improved recommendations.md**: Superpowers gets a dedicated section with per-harness plugin install commands.

**Bug fixes** (found via Superpowers systematic-debugging + verification review):
- installSkill() now checks result.error before result.status (handles missing npx gracefully)
- Auto-install is idempotent — won't reinstall if config.json is regenerated

### Version: 0.15.0 -> 0.16.0