### PR TITLE
fix: resolve self-scorecard CI failure — dist/generators template path

### DIFF
--- a/bundle/generate.js
+++ b/bundle/generate.js
@@ -434,7 +434,11 @@ function sanitizeForInstructions(value, maxLength = 128) {
 function resolveTemplatesDir(runtimeDir) {
   const candidates = [
     path3.join(runtimeDir, "..", "templates"),
-    path3.join(runtimeDir, "..", "src", "templates")
+    // bundle/generate.js → templates/  |  dist/generators/ → dist/templates/
+    path3.join(runtimeDir, "..", "src", "templates"),
+    // bundle/generate.js → src/templates/ ✓  |  src/generators/ → src/templates/ ✓
+    path3.join(runtimeDir, "..", "..", "src", "templates")
+    // dist/generators/ → src/templates/ ✓ (tsc compiled layout)
   ];
   for (const candidate of candidates) {
     if (fs2.existsSync(candidate) && fs2.statSync(candidate).isDirectory()) {

--- a/dist/bundle-manifest.json
+++ b/dist/bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "bundledAt": "2026-05-10T05:00:25.449Z",
+  "bundledAt": "2026-05-10T05:28:20.102Z",
   "sourceVersion": "0.16.0",
   "entryPoint": "server.js",
   "sha256": "9f73a228489b69f5286cdd5988eef253b05ece63dd262faa0e705717e4217e2e",

--- a/src/generators/utils.ts
+++ b/src/generators/utils.ts
@@ -305,8 +305,9 @@ export function sanitizeForInstructions(value: string, maxLength = 128): string 
  */
 export function resolveTemplatesDir(runtimeDir: string): string {
   const candidates = [
-    path.join(runtimeDir, '..', 'templates'),
-    path.join(runtimeDir, '..', 'src', 'templates'),
+    path.join(runtimeDir, '..', 'templates'),              // bundle/generate.js → templates/  |  dist/generators/ → dist/templates/
+    path.join(runtimeDir, '..', 'src', 'templates'),       // bundle/generate.js → src/templates/ ✓  |  src/generators/ → src/templates/ ✓
+    path.join(runtimeDir, '..', '..', 'src', 'templates'), // dist/generators/ → src/templates/ ✓ (tsc compiled layout)
   ];
 
   for (const candidate of candidates) {


### PR DESCRIPTION
Hotfix for the CI failure shown on master. Merges the template path fix (PR #160) to master to restore green CI and trigger the release automation for v0.16.0.