### PR TITLE
fix: resolve MCP server version from runtime-manifest.json (v0.22.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-os",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-os",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-os",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Portable AI OS — scans any repo and generates optimized GitHub Copilot context, agents, skills, MCP tools, and slash-command prompts",
   "type": "module",
   "engines": {

--- a/src/mcp-server/sdk-server.ts
+++ b/src/mcp-server/sdk-server.ts
@@ -11,7 +11,6 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import path from 'node:path';
-import { createRequire } from 'node:module';
 import {
   getProjectRoot,
   readAiOsFile,
@@ -49,6 +48,7 @@ import {
   searchSymbols,
   getFilePurpose,
 } from './utils.js';
+import { resolveMcpServerVersion } from './shared.js';
 import { detectDrift, formatDriftReport } from '../detectors/drift.js';
 import { readFile, listDirectory, runTests, runLint, runBuild } from './filesystem.js';
 import { listWorkflows, loadWorkflow, validateWorkflow, buildWorkflowRunPlan, formatRunPlan } from '../workflow-runner.js';
@@ -72,8 +72,7 @@ function wrap(
 }
 
 export function createSdkServer(): McpServer {
-  const req = createRequire(import.meta.url);
-  const pkgVersion = (req('../../package.json') as { version: string }).version;
+  const pkgVersion = resolveMcpServerVersion(import.meta.url);
 
   const server = new McpServer({ name: 'ai-os', version: pkgVersion });
 

--- a/src/mcp-server/shared.ts
+++ b/src/mcp-server/shared.ts
@@ -5,6 +5,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ── Project root ───────────────────────────────────────────────────────────────
 
@@ -87,6 +88,37 @@ export function ensureSessionMemoryStore(): void {
   if (!fs.existsSync(failurePath)) {
     fs.writeFileSync(failurePath, '', 'utf-8');
   }
+}
+
+// ── Bundle version resolution ─────────────────────────────────────────────────
+
+/**
+ * Resolves the AI OS bundle version for use in the installed MCP server.
+ *
+ * When the bundle runs from `.github/ai-os/mcp-server/index.js`, relative paths
+ * like `../../package.json` incorrectly resolve to `.github/package.json`.
+ * Instead, we read `runtime-manifest.json` (co-located with the bundle) which
+ * the installer always writes with the correct `sourceVersion`. Falls back to
+ * the development-time `../../package.json` path and then to `'0.0.0'`.
+ */
+export function resolveMcpServerVersion(importMetaUrl: string): string {
+  const dir = path.dirname(fileURLToPath(importMetaUrl));
+
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(dir, 'runtime-manifest.json'), 'utf-8'),
+    ) as { sourceVersion?: string };
+    if (manifest.sourceVersion) return manifest.sourceVersion;
+  } catch { /* not installed yet — fall through to dev path */ }
+
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(dir, '..', '..', 'package.json'), 'utf-8'),
+    ) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch { /* dev package.json not found */ }
+
+  return '0.0.0';
 }
 
 // ── I/O utilities ──────────────────────────────────────────────────────────────

--- a/src/mcp-server/utils.ts
+++ b/src/mcp-server/utils.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getLatestResolvableVersion } from '../updater.js';
-import { ROOT, readAiOsFile as _readAiOsFile } from './shared.js';
+import { ROOT, readAiOsFile as _readAiOsFile, resolveMcpServerVersion } from './shared.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -89,11 +89,8 @@ export function checkForUpdates(): string {
 
   let toolVersion = '0.0.0';
   try {
-    const toolPkg = JSON.parse(
-      fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf-8'),
-    ) as { version?: string };
-    toolVersion = toolPkg.version ?? '0.0.0';
-  } catch { /* tool package.json not found */ }
+    toolVersion = resolveMcpServerVersion(import.meta.url);
+  } catch { /* ignore */ }
 
   const latestVersion = getLatestResolvableVersion(toolVersion);
 


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the installed MCP server bundle.

### Root cause
The bundled MCP server runs from .github/ai-os/mcp-server/index.js. Relative paths like ../../package.json resolve to .github/package.json, which does not exist in standard repos.

### Fixes
- #219 (Fatal crash): sdk-server.ts used require('../../package.json') - replaced with resolveMcpServerVersion(import.meta.url)
- #218 (Wrong version report): utils.ts read ../../package.json for toolVersion - replaced with same helper

### New helper: resolveMcpServerVersion(importMetaUrl)
Added to shared.ts. Resolution order:
1. ./runtime-manifest.json -> sourceVersion (co-located with installed bundle, written by installer)
2. ../../package.json -> version (dev context fallback)
3. '0.0.0' (last resort)

### Version bump
0.22.0 to 0.22.1

Closes #219, closes #218