### PR TITLE
fix(mcp): use import type for CopilotClient to resolve TS2419 CI failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-os",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-os",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-os",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Portable AI OS — scans any repo and generates optimized GitHub Copilot context, agents, skills, MCP tools, and slash-command prompts",
   "type": "module",
   "engines": {

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -12,6 +12,7 @@
  * Protocol: MCP 2025-11-25 (JSON-RPC over stdio via @modelcontextprotocol/sdk)
  * Requirements: Node.js >= 20
  */
+import type { CopilotClient as CopilotClientClass } from '@github/copilot-sdk';
 import { getProjectRoot } from './utils.js';
 import { getActiveToolsForProject, type McpToolDefinition } from './tool-definitions.js';
 import { runSdkMcp, createSdkServer } from './sdk-server.js';
@@ -76,15 +77,7 @@ async function main(): Promise<void> {
     throw new Error(`MCP runtime validation failed: ${health.messages.join(' | ')}`);
   }
 
-  let CopilotClient: new () => {
-    start(): Promise<void>;
-    stop(): Promise<unknown>;
-    createSession(opts: {
-      model: string;
-      tools: Array<{ name: string; description: string; parameters: Record<string, unknown>; handler: (input: Record<string, unknown>) => Promise<string> }>;
-      onPermissionRequest: (_req: unknown) => { kind: 'approved' };
-    }): Promise<{ disconnect(): Promise<void> }>;
-  };
+  let CopilotClient: typeof CopilotClientClass;
 
   try {
     const sdk = await import('@github/copilot-sdk');


### PR DESCRIPTION
## Summary

Fixes the CI failure introduced when dependabot merged PR #217 bumping \@github/copilot-sdk\ from 0.1.32 → 0.3.0.

### Root Cause
The local interface in \src/mcp-server/index.ts\ declared \CopilotClient\ as:
\\\	ypescript
let CopilotClient: new () => { start, stop, createSession };
\\\
The v0.3.0 SDK changed the constructor to \constructor(options?: CopilotClientOptions)\ — a different construct signature that TypeScript (TS2419) rejected when assigning \sdk.CopilotClient\.

### Fix
Replace the manual interface with the SDK's own type:
\\\	ypescript
import type { CopilotClient as CopilotClientClass } from '@github/copilot-sdk';
let CopilotClient: typeof CopilotClientClass;
\\\
This ensures the declared type always matches the installed SDK version.

### Validation
- \
pm run build\ — clean ✅
- \
pm run test\ — 614/614 pass ✅
- Version bumped: 0.22.2 → 0.22.3

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>