### PR TITLE
feat(spec-trace): Spec Traceability v0.22.4 (RII Phase 2)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "stdio",
       "command": "node",
       "args": [
-        ".ai-os/mcp-server/index.js"
+        ".github/ai-os/mcp-server/index.js"
       ],
       "env": {
         "AI_OS_ROOT": "."

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -1,0 +1,148 @@
+# ai-os — Improvement & Optimization Plan (audited)
+
+> Status: proposal for review. Each item is rated **Necessary**, **Recommended**, or **Optional** based on a critical audit of the codebase as of v0.12.1.
+
+## Repository purpose (restated)
+
+ai-os is a **portable GitHub Copilot context engine** — a Node ≥20 CLI that scans any target repository, detects its stack, and emits a manifest-tracked Copilot context package (instructions, agents, skills, MCP tools, prompts, workflows, memory store, freshness snapshot). It also ships a self-contained MCP runtime server (`dist/server.js`) plus validation tooling (regression, smoke, scorecard, doctor).
+
+The bar for any change: must improve **generation correctness, install/refresh reliability, security, or developer velocity** without breaking the manifest-tracked artifact contract that downstream repos depend on.
+
+---
+
+## Audit summary (what changed from the first-pass plan)
+
+After a critical re-read of the source the following changes were applied:
+
+- **Promoted to top-priority Necessary:** shell-injection fix in `searchFiles` MCP tool (concrete vulnerability confirmed at `src/mcp-server/utils.ts:1372`).
+- **Demoted / dropped as speculative:** lazy-loaded action modules (bundle is already 261 KB — premature), recommendation plugin system (no contributor demand yet, large surface area), separate Windows PowerShell installer (`npx` already works on Windows; `install.sh` is bash-only by choice).
+- **Scope-corrected:** schema validation switches from "add zod" to **hand-rolled type guards** to preserve the deliberate single-runtime-dep posture (`@github/copilot-sdk` only).
+- **Newly added items found during audit:**
+  - Sanitize stack-derived strings before they land in generated `copilot-instructions.md` (prompt-injection surface from package names, README excerpts, etc.).
+  - Versioned artifact schemas + forward-migration path (manifest currently has no `schemaVersion`).
+  - Public `--uninstall` action that consumes the manifest (currently only `pruneLegacyArtifacts` exists internally).
+
+The full validated roadmap is below. Items marked **Necessary** should ship before the next minor release; **Recommended** items materially improve the product; **Optional** items are nice-to-have.
+
+---
+
+
+## Phase 0 — Security must-fixes (Necessary, do first)
+
+### 0.1 Fix shell injection in `searchFiles` MCP tool — **Necessary**
+- **Evidence:** `src/mcp-server/utils.ts:1372` interpolates user-controlled `query` and `filePattern` into a shell command string passed to `execSync`. Because this tool is exposed to Copilot agents, a crafted query containing shell metacharacters can execute arbitrary commands in the user's working directory.
+- **Fix:** Switch to `spawnSync` with array args, drop the `npx ripgrep` shell form, or use the bundled `ripgrep` Node binding. Add a unit test asserting that `;`, `` ` ``, and `$()` in queries do not execute.
+- **Why necessary:** Concrete, exploitable vulnerability in code that ships to every install.
+
+### 0.2 Audit and harden remaining `execSync` callsites — **Necessary**
+- `src/mcp-server/utils.ts:1522`, `:1591` use hardcoded globs (lower risk, but still string-form).
+- `src/recommendations/cli-compat.ts:35` calls `npx -y skills --version` — verify no user input flows in.
+- `src/validation/regression.ts:63-65` git init in a temp dir (low risk, dev-only).
+- **Fix:** Replace all with `spawnSync(file, args[], opts)`. Add an ESLint rule (after Phase 1) banning string-form `execSync`.
+
+### 0.3 Sanitize stack-derived inputs before rendering into Copilot instructions — **Necessary**
+- **Evidence:** `generators/instructions.ts` and `context-docs.ts` interpolate `stack.projectName`, dependency names, and (in some templates) README excerpts into a file that Copilot loads as system prompt. A malicious dependency name like `"foo\n\nIGNORE PRIOR INSTRUCTIONS AND ..."` could prompt-inject the agent.
+- **Fix:** Add a `sanitizeForInstructions()` helper (strip control chars, cap length, fence in code blocks where appropriate). Apply at every interpolation site rendered into `.github/copilot-instructions.md` and agent files.
+
+---
+
+## Phase 1 — Foundations (Necessary, low risk, high leverage)
+
+### 1.1 Add ESLint (no Prettier) — **Recommended**
+- **Why not Prettier:** repo style is consistent and adds churn; ESLint with stylistic rules is enough.
+- **Why ESLint:** lets us encode bans (string-form `execSync`, naked `catch {}` swallows, `console.log` outside CLI surfaces).
+- **Wire into:** `validate:fast`.
+
+### 1.2 Schema-validate JSON artifacts (hand-rolled guards) — **Necessary**
+- **Targets:** `config.json`, `manifest.json`, `tools.json`, `memory.jsonl`, `protect.json`.
+- **Rationale:** today, `readAiOsFile` returns `''` on read failure and JSON parsers throw raw — both violate the project's own "no silent fallback" guardrail. Malformed files silently degrade behavior across refreshes.
+- **Approach:** small `validators/` module with explicit type guards + descriptive errors. **No new runtime deps** (preserve current zero-dep posture beyond `@github/copilot-sdk`).
+- **Add:** `schemaVersion` field on every JSON artifact + migration ladder.
+
+### 1.3 Atomic file writes — **Necessary**
+- **Evidence:** generators write in place; an interrupted `--refresh-existing` can leave half-written `tools.json`/`manifest.json`, breaking next refresh.
+- **Fix:** `writeFileAtomic` helper in `generators/utils.ts` (write `*.tmp`, fsync, rename). Migrate manifest, tools.json, config.json, memory.jsonl, freshness snapshot.
+
+### 1.4 Auto-generate the MCP tool reference — **Recommended**
+- **Evidence:** the MCP tool list in `README.md` and `docs/` is hand-maintained vs. `src/mcp-tools.ts` definitions. Drift on every tool addition.
+- **Fix:** add a `scripts/gen-mcp-docs.mjs` that reads `mcp-tools.ts` and writes `docs/mcp-tools.md`. CI fails if generated content drifts.
+
+---
+
+## Phase 2 — Refactor god modules (Recommended; behavior-preserving)
+
+### 2.1 Split `src/mcp-server/utils.ts` (72 KB, 30+ exports) — **Recommended**
+- **Evidence:** the file mixes memory store, session state, freshness, package introspection, env var scanning, search, recommendations bridge.
+- **Target layout:** `memory.ts`, `session.ts`, `freshness-bridge.ts`, `project-introspection.ts` (env/package/files/routes), `search.ts`, `recommendations-bridge.ts`. Re-export from `utils.ts` for one minor release for backward compat.
+- **Why not Necessary:** it works today; benefit is reviewability and unlocking 2.3.
+
+### 2.2 Split `src/generate.ts` (45 KB) — **Recommended**
+- **Layout:** `cli/args.ts`, `cli/dispatch.ts`, `actions/{apply,doctor,bootstrap,check-freshness,check-hygiene,compact-memory,plan,preview}.ts`. Keep `generate.ts` as a thin entry.
+
+### 2.3 Expand unit test coverage — **Necessary**
+- **Evidence:** 15 test files for ~104 source files (~14% file coverage). No tests for `analyze.ts`, `generate.ts` action dispatch, `generators/context-docs.ts`, or most of `mcp-server/utils.ts`.
+- **Target:** >40% file coverage on critical paths (analyze, generators, mcp-server). Add fixtures for representative stacks.
+
+---
+
+## Phase 3 — Reliability & UX (mixed priority)
+
+### 3.1 Content-hash gate per artifact — **Recommended**
+- **Behavior:** store input + template hashes in manifest entries; skip writes when unchanged. Speeds `--refresh-existing` on stable repos and reduces churn in user PRs.
+
+### 3.2 Real diff in `--dry-run` — **Recommended**
+- **Today:** prints planned actions only, no content delta.
+- **Fix:** unified-diff helper; show summary counts + first N changed lines per artifact.
+
+### 3.3 `--uninstall` action — **Necessary**
+- **Evidence:** today only `pruneLegacyArtifacts` exists internally. Users have no clean way to remove ai-os from a target repo.
+- **Behavior:** consume the manifest, remove every owned file, leave user-authored blocks intact (already supported via `user-blocks.ts`), report what was kept and why.
+
+### 3.4 `--json` output mode — **Optional**
+- For `apply`, `doctor`, `check-freshness`, `check-hygiene`. Useful for CI consumers; defer until first request.
+
+---
+
+## Phase 4 — Security & supply chain (Necessary)
+
+### 4.1 `npm audit --omit=dev` gate in CI — **Necessary**
+- Add to `.github/workflows/ai-os-validate.yml`. Fail on high/critical, warn on moderate.
+
+### 4.2 Bundle provenance on releases — **Recommended**
+- Publish SHA-256 of `bundle/generate.js` and `dist/server.js` in the GitHub Release notes; document verification step in README.
+
+### 4.3 Self-host scorecard in CI — **Recommended**
+- Run ai-os against itself and assert the scorecard meets a threshold; prevents detection regressions for TS/Node/Vitest stacks.
+
+---
+
+## Phase 5 — Documentation (Recommended)
+
+### 5.1 Split `README.md` into `docs/` — **Recommended**
+- `README.md` → quickstart only.
+- `docs/cli.md` (flags), `docs/mcp-tools.md` (generated), `docs/architecture.md`, `docs/contributing.md`.
+
+### 5.2 Auto-run `--doctor` at end of `install.sh` — **Recommended**
+- Already implemented; just wire into the installer with a soft-fail summary.
+
+### 5.3 `examples/` reference repos with snapshot fixtures — **Recommended**
+- 3 reference targets (Next.js + tRPC, FastAPI, Go service) with expected-output snapshots. Doubles as regression bedrock.
+
+---
+
+## Explicitly out of scope
+
+- Telemetry that leaves the user's machine (privacy posture).
+- Bundler rewrite (esbuild config is fine).
+- Multi-language port of the CLI.
+- Recommendation plugin system (no demand; large surface area).
+- Lazy-loaded action modules (bundle already small).
+- Separate PowerShell installer (`npx` works cross-platform).
+
+---
+
+## Open questions
+
+- Should we drop the committed `dist/` and produce it only at release time? Current setup makes `npx github:...` work without a build step; likely keep.
+- Memory store currently lives in target repo only — is there appetite for an opt-in shared/global tier?
+- Should generated artifact files include a top-comment with `schemaVersion` so external tooling can detect compatibility without parsing?

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -48,6 +48,8 @@
 | `detect_intent` | Classifies the intent of a user prompt into one of 9 categories (new-feature, bug-fix, refactor, db-change, test-addition, dependency-update, docs-update, config-change, quick-edit). Returns intentType, confidence, affectedDomain, suggestedSkill, and an optional WORKFLOW-FORK clarifying question. Works without repo-index (keyword-only fallback). |
 | `search_symbols` | Searches the Repository Intelligence Index (repo-index.jsonl) for named symbols (functions, classes, interfaces, types, enums, variables) by name query. Optionally filter by kind (function | class | interface | type | variable | enum | method) or by tag (auth, database, api, testing, ui, etc.). Returns up to 30 matching symbols with file path, line, signature, and tags. Requires `ai-os --index` to have been run first; gracefully returns empty list if no index exists. |
 | `get_file_purpose` | Returns a concise description of what a source file does, its exports, domain tags, size, and language — sourced from the Repository Intelligence Index (repo-index.jsonl). Requires `ai-os --index` to have been run first. Returns null if no index or no entry for the given file path exists. |
+| `validate_spec_coverage` | Reports spec requirement coverage across all spec files in the repo index. Groups requirements by spec file and shows which are annotated with @spec: (implemented) and which are gaps. Requires `ai-os --index` to have run first. |
+| `get_spec_for_file` | Returns the spec requirements (with IDs and titles) that a given source file implements, based on @spec: annotations in the repo index. Requires `ai-os --index` to have run first. |
 
 ## Session Start Protocol
 

--- a/docs/superpowers/plans/2026-05-27-spec-traceability.md
+++ b/docs/superpowers/plans/2026-05-27-spec-traceability.md
@@ -1,0 +1,953 @@
+# Spec Traceability (RII Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Link spec markdown files to implementing code via `@spec:` annotations and expose coverage reporting through two new MCP tools.
+
+**Architecture:** A new `spec-parser.ts` module parses spec files and auto-assigns stable IDs from filenames + heading order. The `indexRepo()` pipeline gains a spec scan step that matches those IDs against `@spec:` annotations already captured by `parseSpecIds()` (already live in `symbols.ts`). Two new MCP tools (`validate_spec_coverage`, `get_spec_for_file`) query the emitted `SpecIndexEntry` records.
+
+**Tech Stack:** TypeScript, Node.js `fs`, Vitest, `@modelcontextprotocol/sdk`, Zod.
+
+---
+
+## Key Codebase Facts (read before touching code)
+
+- `parseSpecIds()` in `src/detectors/symbols.ts` **already captures** `@spec: ID` annotations — no changes needed to `symbols.ts`.
+- `SpecIndexEntry` **already declared** in `src/types.ts` lines 282–290 — no changes needed to `types.ts`.
+- `specIds: string[]` **already flows** from `SymbolExtract` → `SymbolIndexEntry` in `src/actions/index.ts` line 158.
+- `src/mcp-server/utils.ts` re-exports `export * from './search.js'` — new functions in `search.ts` are automatically available in `sdk-server.ts` imports.
+- All tools registered in `sdk-server.ts` must also be mirrored in `src/mcp-tools.ts`.
+- Default spec dir: `docs/superpowers/specs/` relative to repo root.
+- Run with: `npm run build && npm run test`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/generators/spec-parser.ts` | **Create** | `deriveSpecPrefix()` + `parseSpecFiles()` |
+| `src/tests/spec-traceability.test.ts` | **Create** | All unit + integration tests |
+| `src/cli/args.ts` | **Modify** | Add `specDir?: string` to `ParsedArgs` + `--spec-dir` flag |
+| `src/actions/index.ts` | **Modify** | Add `specDir?` to `IndexOptions`, `buildSpecEntries()` helper, emit `SpecIndexEntry` records |
+| `src/cli/dispatch.ts` | **Modify** | Pass `specDir` to `indexRepo()` |
+| `src/mcp-server/search.ts` | **Modify** | Add `validateSpecCoverage()` + `getSpecForFile()` |
+| `src/mcp-server/sdk-server.ts` | **Modify** | Register tools #42 and #43 |
+| `src/mcp-tools.ts` | **Modify** | Add tool definitions #42 and #43 |
+
+---
+
+## Task 1: Write failing tests for `spec-parser.ts`
+
+**Files:**
+- Create: `src/tests/spec-traceability.test.ts`
+
+- [ ] **Step 1.1: Create the test file**
+
+```typescript
+// src/tests/spec-traceability.test.ts
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { deriveSpecPrefix, parseSpecFiles } from '../generators/spec-parser.js';
+import type { SpecIndexEntry, RepoIndexEntry } from '../types.js';
+
+function makeTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'spec-trace-test-'));
+}
+function write(dir: string, rel: string, content: string): void {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf-8');
+}
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+// ── deriveSpecPrefix ──────────────────────────────────────────────────────────
+
+describe('deriveSpecPrefix', () => {
+  it.each([
+    ['2026-05-25-repo-intelligence-index-design.md', 'REPO-INTEL'],
+    ['2026-05-11-a2a-orchestrator-design.md', 'A2A-ORCH'],
+    ['2026-05-25-prompt-booster-design.md', 'PROMPT-BOOST'],
+    ['2026-05-27-spec-traceability-design.md', 'SPEC-TRACE'],
+    ['2026-01-01-single-design.md', 'SINGLE'],
+    ['plain.md', 'PLAIN'],
+  ])('%s → %s', (input: string, expected: string) => {
+    expect(deriveSpecPrefix(input)).toBe(expected);
+  });
+});
+
+// ── parseSpecFiles ────────────────────────────────────────────────────────────
+
+describe('parseSpecFiles', () => {
+  it('returns [] when specDir does not exist', () => {
+    expect(parseSpecFiles('/this/path/does/not/exist')).toEqual([]);
+  });
+
+  it('returns one entry per H2/H3 heading in document order', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-01-my-feature-design.md', [
+      '# My Feature',
+      '## Overview',
+      '## API Shape',
+      '### Sub-section',
+      '#### H4 is ignored',
+    ].join('\n'));
+    const results = parseSpecFiles(path.join(tmp, 'specs'));
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({ specId: 'MY-FEAT-1', title: 'Overview', requirementCount: 3 });
+    expect(results[1]).toMatchObject({ specId: 'MY-FEAT-2', title: 'API Shape', requirementCount: 3 });
+    expect(results[2]).toMatchObject({ specId: 'MY-FEAT-3', title: 'Sub-section', requirementCount: 3 });
+  });
+
+  it('ignores headings inside code fences', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-01-example-design.md', [
+      '## Real Heading',
+      '```',
+      '## Fake Heading inside fence',
+      '```',
+      '## Another Real Heading',
+    ].join('\n'));
+    const results = parseSpecFiles(path.join(tmp, 'specs'));
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ specId: 'EXAMPLE-1', title: 'Real Heading' });
+    expect(results[1]).toMatchObject({ specId: 'EXAMPLE-2', title: 'Another Real Heading' });
+  });
+
+  it('processes multiple spec files sorted alphabetically by filename', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-02-beta-design.md', '## Beta Req\n## Beta Req 2');
+    write(tmp, 'specs/2026-01-01-alpha-design.md', '## Alpha Req');
+    const results = parseSpecFiles(path.join(tmp, 'specs'));
+    expect(results[0]).toMatchObject({ specId: 'ALPHA-1', specFile: '2026-01-01-alpha-design.md' });
+    expect(results[1]).toMatchObject({ specId: 'BETA-1', specFile: '2026-01-02-beta-design.md' });
+    expect(results[2]).toMatchObject({ specId: 'BETA-2', specFile: '2026-01-02-beta-design.md' });
+  });
+
+  it('returns [] for a spec file with no H2/H3 headings', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-01-empty-design.md', '# Only H1\n#### Only H4');
+    expect(parseSpecFiles(path.join(tmp, 'specs'))).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the tests to verify they fail (module not found)**
+
+```
+npm run test -- --reporter=verbose src/tests/spec-traceability.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../generators/spec-parser.js'`
+
+---
+
+## Task 2: Implement `src/generators/spec-parser.ts`
+
+**Files:**
+- Create: `src/generators/spec-parser.ts`
+
+- [ ] **Step 2.1: Create the module**
+
+```typescript
+/**
+ * spec-parser.ts — Parses spec markdown files and derives stable spec IDs.
+ *
+ * Part of the Repository Intelligence Index (RII) Phase 2.
+ * No external dependencies — regex over file content only.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface ParsedSpec {
+  /** Stable ID, e.g. "REPO-INTEL-3". One per H2/H3 heading. */
+  specId: string;
+  /** Heading text, e.g. "CLI Command: ai-os index". */
+  title: string;
+  /** Basename of spec file, e.g. "2026-05-25-repo-intelligence-index-design.md". */
+  specFile: string;
+  /** Total H2/H3 headings in this file (for context display). */
+  requirementCount: number;
+}
+
+/**
+ * Derives the spec ID prefix from a spec filename.
+ * "2026-05-25-repo-intelligence-index-design.md" → "REPO-INTEL"
+ */
+export function deriveSpecPrefix(filename: string): string {
+  const base = path.basename(filename, '.md');
+  const slug = base
+    .replace(/^\d{4}-\d{2}-\d{2}-/, '')  // strip YYYY-MM-DD-
+    .replace(/-design$/, '');             // strip trailing -design
+  const words = slug.split('-').filter(Boolean);
+  return words.slice(0, 2).join('-').toUpperCase();
+}
+
+/**
+ * Parses all .md files in specDir and returns one ParsedSpec per H2/H3 heading per file.
+ * Returns [] gracefully when specDir does not exist.
+ */
+export function parseSpecFiles(specDir: string): ParsedSpec[] {
+  if (!fs.existsSync(specDir)) return [];
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(specDir).filter(f => f.endsWith('.md')).sort();
+  } catch {
+    return [];
+  }
+
+  const results: ParsedSpec[] = [];
+
+  for (const file of files) {
+    let content: string;
+    try {
+      content = fs.readFileSync(path.join(specDir, file), 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const prefix = deriveSpecPrefix(file);
+    const headings = extractHeadings(content);
+
+    for (let i = 0; i < headings.length; i++) {
+      results.push({
+        specId: `${prefix}-${i + 1}`,
+        title: headings[i] ?? '',
+        specFile: file,
+        requirementCount: headings.length,
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Extracts H2/H3 heading text, ignoring content inside code fences. */
+function extractHeadings(content: string): string[] {
+  const stripped = content.replace(/```[\s\S]*?```/g, '');
+  const re = /^#{2,3}\s+(.+)$/gm;
+  const headings: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stripped)) !== null) {
+    const text = m[1]?.trim();
+    if (text) headings.push(text);
+  }
+  return headings;
+}
+```
+
+- [ ] **Step 2.2: Run the spec-parser tests**
+
+```
+npm run test -- --reporter=verbose src/tests/spec-traceability.test.ts
+```
+
+Expected: all `deriveSpecPrefix` and `parseSpecFiles` tests PASS (integration tests for `indexRepo` will still fail — that's expected).
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add src/generators/spec-parser.ts src/tests/spec-traceability.test.ts
+git commit -m "feat(spec-trace): add spec-parser module with tests"
+```
+
+---
+
+## Task 3: Add `--spec-dir` CLI flag
+
+**Files:**
+- Modify: `src/cli/args.ts`
+
+- [ ] **Step 3.1: Add `specDir` to `ParsedArgs` and `parseArgs()`**
+
+In `src/cli/args.ts`, find the `ParsedArgs` interface and add after `incremental: boolean;`:
+
+```typescript
+  specDir: string | undefined;
+```
+
+Find `let incremental = false;` and add after it:
+
+```typescript
+  let specDir: string | undefined = undefined;
+```
+
+Find the block `} else if (args[i] === '--incremental') {` and add after its closing `}`:
+
+```typescript
+    } else if (args[i] === '--spec-dir' && args[i + 1]) {
+      specDir = path.resolve(args[i + 1] as string);
+      i++;
+    } else if (args[i]?.startsWith('--spec-dir=')) {
+      specDir = path.resolve(args[i].slice('--spec-dir='.length));
+```
+
+Find the return statement and add `specDir` to it (after `incremental`):
+
+```typescript
+  return { cwd, dryRun, mode, action, prune, verbose, cleanUpdate, regenerateContext,
+           pruneCustomArtifacts, profile, json, fullDiff, editorTargets, model,
+           incremental, specDir };
+```
+
+- [ ] **Step 3.2: Run the existing CLI args tests**
+
+```
+npm run test -- --reporter=verbose src/tests/cli-args.test.ts
+```
+
+Expected: all existing CLI args tests PASS (no regressions).
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/cli/args.ts
+git commit -m "feat(spec-trace): add --spec-dir CLI flag"
+```
+
+---
+
+## Task 4: Update `indexRepo()` to emit `SpecIndexEntry` records
+
+**Files:**
+- Modify: `src/actions/index.ts`
+
+- [ ] **Step 4.1: Add the spec scan step**
+
+At the top of `src/actions/index.ts`, add to the existing imports block:
+
+```typescript
+import { parseSpecFiles } from '../generators/spec-parser.js';
+import type { SpecIndexEntry } from '../types.js';
+```
+
+Add `specDir?: string` to `IndexOptions` (after `quiet?: boolean`):
+
+```typescript
+  /** Directory containing spec .md files. Defaults to docs/superpowers/specs/. */
+  specDir?: string;
+```
+
+Add `buildSpecEntries` function at the bottom of the file (before or after `inferLanguage`):
+
+```typescript
+function buildSpecEntries(
+  specDirPath: string,
+  allSymbols: SymbolIndexEntry[],
+): SpecIndexEntry[] {
+  const parsed = parseSpecFiles(specDirPath);
+  if (parsed.length === 0) return [];
+
+  // Map specId (normalised uppercase) → set of files that annotate it
+  const implementedByMap = new Map<string, Set<string>>();
+  for (const sym of allSymbols) {
+    for (const specId of sym.specIds) {
+      const normalized = specId.toUpperCase();
+      if (!implementedByMap.has(normalized)) {
+        implementedByMap.set(normalized, new Set<string>());
+      }
+      implementedByMap.get(normalized)!.add(sym.file);
+    }
+  }
+
+  return parsed.map(p => {
+    const implementedBy = [...(implementedByMap.get(p.specId) ?? [])];
+    return {
+      type: 'spec' as const,
+      specId: p.specId,
+      title: p.title,
+      specFile: p.specFile,
+      requirementCount: p.requirementCount,
+      implementedBy,
+      coverageRatio: implementedBy.length > 0 ? 1.0 : 0.0,
+    };
+  });
+}
+```
+
+- [ ] **Step 4.2: Add spec scan in `indexRepo()` after the file scanning loop**
+
+In `indexRepo()`, find the line:
+
+```typescript
+  const allEntries: RepoIndexEntry[] = [meta, ...fileEntries, ...symbolEntries];
+```
+
+Replace with:
+
+```typescript
+  // Build spec entries — include unchanged symbols too in incremental mode
+  const specDirPath = opts.specDir ?? path.join(cwd, 'docs', 'superpowers', 'specs');
+  const existingSymbolsForSpec = incremental && fs.existsSync(outputPath)
+    ? loadExistingEntries(outputPath)
+        .filter((e): e is SymbolIndexEntry => {
+          const changedPaths = new Set(fileEntries.map(f => f.path));
+          return e.type === 'symbol' && !changedPaths.has(e.file);
+        })
+    : [];
+  const specEntries = buildSpecEntries(specDirPath, [...symbolEntries, ...existingSymbolsForSpec]);
+
+  const allEntries: RepoIndexEntry[] = [meta, ...fileEntries, ...symbolEntries, ...specEntries];
+```
+
+- [ ] **Step 4.3: Update the incremental merge block to regenerate spec entries**
+
+Find the incremental write block. Change the `return true; // keep spec entries` line:
+
+```typescript
+      if (e.type === 'spec') return false; // regenerated fresh on every run
+```
+
+And update the merged array to include `specEntries`:
+
+```typescript
+      const merged: RepoIndexEntry[] = [meta, ...fileEntries, ...symbolEntries, ...specEntries, ...keptEntries];
+```
+
+- [ ] **Step 4.4: Plumb `specDir` through `dispatch.ts`**
+
+In `src/cli/dispatch.ts`, find the `indexRepo({` call and add `specDir`:
+
+```typescript
+    await indexRepo({
+      cwd,
+      incremental: args.incremental,
+      regenContext: args.regenerateContext,
+      dryRun: args.dryRun,
+      quiet: args.json,
+      specDir: args.specDir,
+    });
+```
+
+- [ ] **Step 4.5: Add indexRepo integration tests to the test file**
+
+Append to `src/tests/spec-traceability.test.ts`:
+
+```typescript
+// ── indexRepo integration ─────────────────────────────────────────────────────
+
+import { indexRepo } from '../actions/index.js';
+
+function readJsonl(p: string): RepoIndexEntry[] {
+  return fs.readFileSync(p, 'utf-8')
+    .split('\n').filter(Boolean)
+    .map(l => JSON.parse(l) as RepoIndexEntry);
+}
+
+describe('indexRepo — SpecIndexEntry emission', () => {
+  it('emits SpecIndexEntry records when spec files and annotations exist', async () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'src/index.ts', [
+      '// @spec: MY-FEAT-1',
+      'export function doThing(): void {}',
+    ].join('\n'));
+    write(tmp, 'docs/superpowers/specs/2026-01-01-my-feature-design.md', [
+      '## Overview',
+      '## Detail',
+    ].join('\n'));
+
+    const result = await indexRepo({ cwd: tmp, quiet: true });
+    const entries = readJsonl(result.outputPath);
+    const specs = entries.filter((e): e is SpecIndexEntry => e.type === 'spec');
+
+    expect(specs).toHaveLength(2);
+
+    const covered = specs.find(s => s.specId === 'MY-FEAT-1');
+    expect(covered).toBeDefined();
+    expect(covered!.implementedBy).toContain('src/index.ts');
+    expect(covered!.coverageRatio).toBe(1.0);
+
+    const uncovered = specs.find(s => s.specId === 'MY-FEAT-2');
+    expect(uncovered).toBeDefined();
+    expect(uncovered!.implementedBy).toHaveLength(0);
+    expect(uncovered!.coverageRatio).toBe(0.0);
+  });
+
+  it('emits no spec entries when spec dir is absent', async () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'src/index.ts', 'export function foo() {}');
+    const result = await indexRepo({ cwd: tmp, quiet: true });
+    const entries = readJsonl(result.outputPath);
+    expect(entries.filter(e => e.type === 'spec')).toHaveLength(0);
+  });
+
+  it('uses custom specDir when provided', async () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'src/index.ts', '// @spec: FOO-1\nexport function foo() {}');
+    write(tmp, 'custom/2026-01-01-foo-design.md', '## Req One');
+    const result = await indexRepo({
+      cwd: tmp,
+      quiet: true,
+      specDir: path.join(tmp, 'custom'),
+    });
+    const entries = readJsonl(result.outputPath);
+    const specs = entries.filter((e): e is SpecIndexEntry => e.type === 'spec');
+    expect(specs).toHaveLength(1);
+    expect(specs[0]!.implementedBy).toContain('src/index.ts');
+  });
+});
+```
+
+- [ ] **Step 4.6: Run all spec-traceability tests**
+
+```
+npm run test -- --reporter=verbose src/tests/spec-traceability.test.ts
+```
+
+Expected: spec-parser tests PASS, indexRepo integration tests PASS.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add src/actions/index.ts src/cli/dispatch.ts src/tests/spec-traceability.test.ts
+git commit -m "feat(spec-trace): emit SpecIndexEntry records in indexRepo pipeline"
+```
+
+---
+
+## Task 5: Add MCP helper functions to `search.ts`
+
+**Files:**
+- Modify: `src/mcp-server/search.ts`
+
+- [ ] **Step 5.1: Add the import and interfaces**
+
+At the top of `src/mcp-server/search.ts`, add after the existing imports:
+
+```typescript
+import { deriveSpecPrefix } from '../generators/spec-parser.js';
+```
+
+Add these interfaces and functions at the bottom of `src/mcp-server/search.ts`:
+
+```typescript
+export interface SpecCoverageGroup {
+  specPrefix: string;
+  specFile: string;
+  covered: number;
+  total: number;
+  ratio: number;
+  requirements: Array<{
+    specId: string;
+    title: string;
+    implemented: boolean;
+    implementedBy: string[];
+  }>;
+}
+
+/**
+ * Groups SpecIndexEntry records by spec file and computes per-file coverage.
+ * Falls back gracefully when no index file exists.
+ */
+export function validateSpecCoverage(projectRoot: string): SpecCoverageGroup[] {
+  const raw = readRepoIndex(projectRoot);
+  if (!raw) return [];
+
+  const entries = parseIndexEntries(raw);
+  const specEntries = entries.filter(e => e.type === 'spec');
+  if (specEntries.length === 0) return [];
+
+  const byFile = new Map<string, typeof specEntries>();
+  for (const e of specEntries) {
+    const file = (e['specFile'] as string | undefined) ?? 'unknown';
+    if (!byFile.has(file)) byFile.set(file, []);
+    byFile.get(file)!.push(e);
+  }
+
+  const results: SpecCoverageGroup[] = [];
+  for (const [specFile, reqs] of byFile) {
+    const requirements = reqs.map(e => {
+      const implementedBy = (e['implementedBy'] as string[] | undefined) ?? [];
+      return {
+        specId: (e['specId'] as string | undefined) ?? '',
+        title: (e['title'] as string | undefined) ?? '',
+        implemented: implementedBy.length > 0,
+        implementedBy,
+      };
+    });
+    const covered = requirements.filter(r => r.implemented).length;
+    results.push({
+      specPrefix: deriveSpecPrefix(specFile),
+      specFile,
+      covered,
+      total: requirements.length,
+      ratio: requirements.length > 0 ? covered / requirements.length : 0,
+      requirements,
+    });
+  }
+
+  return results.sort((a, b) => a.specFile.localeCompare(b.specFile));
+}
+
+export interface SpecForFileEntry {
+  specId: string;
+  title: string;
+  specFile: string;
+}
+
+/**
+ * Returns spec requirements implemented by a given file path.
+ * Falls back gracefully when no index file exists.
+ */
+export function getSpecForFile(projectRoot: string, filePath: string): SpecForFileEntry[] {
+  const raw = readRepoIndex(projectRoot);
+  if (!raw) return [];
+
+  const normalised = filePath.replace(/\\/g, '/');
+  const entries = parseIndexEntries(raw);
+  const results: SpecForFileEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.type !== 'spec') continue;
+    const implementedBy = (entry['implementedBy'] as string[] | undefined) ?? [];
+    const isImplemented = implementedBy.some(f => {
+      const fn = f.replace(/\\/g, '/');
+      return fn === normalised || fn.endsWith(`/${normalised}`);
+    });
+    if (isImplemented) {
+      results.push({
+        specId: (entry['specId'] as string | undefined) ?? '',
+        title: (entry['title'] as string | undefined) ?? '',
+        specFile: (entry['specFile'] as string | undefined) ?? '',
+      });
+    }
+  }
+
+  return results;
+}
+```
+
+- [ ] **Step 5.2: Add tests for `validateSpecCoverage` and `getSpecForFile`**
+
+Append to `src/tests/spec-traceability.test.ts`:
+
+```typescript
+// ── validateSpecCoverage ──────────────────────────────────────────────────────
+
+import { validateSpecCoverage, getSpecForFile } from '../mcp-server/search.js';
+
+describe('validateSpecCoverage', () => {
+  it('returns [] when no index file exists', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    expect(validateSpecCoverage(tmp)).toEqual([]);
+  });
+
+  it('groups spec entries by specFile and computes coverage', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    const specEntries: SpecIndexEntry[] = [
+      { type: 'spec', specId: 'FOO-1', title: 'R1', specFile: 'foo.md', requirementCount: 2, implementedBy: ['src/a.ts'], coverageRatio: 1.0 },
+      { type: 'spec', specId: 'FOO-2', title: 'R2', specFile: 'foo.md', requirementCount: 2, implementedBy: [], coverageRatio: 0.0 },
+    ];
+    fs.mkdirSync(path.join(tmp, '.github/ai-os/context'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.github/ai-os/context/repo-index.jsonl'),
+      specEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
+      'utf-8',
+    );
+    const results = validateSpecCoverage(tmp);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ specFile: 'foo.md', covered: 1, total: 2 });
+    expect(results[0]!.ratio).toBeCloseTo(0.5);
+    expect(results[0]!.requirements[0]).toMatchObject({ specId: 'FOO-1', implemented: true });
+    expect(results[0]!.requirements[1]).toMatchObject({ specId: 'FOO-2', implemented: false });
+  });
+});
+
+// ── getSpecForFile ────────────────────────────────────────────────────────────
+
+describe('getSpecForFile', () => {
+  it('returns [] when no index file exists', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    expect(getSpecForFile(tmp, 'src/a.ts')).toEqual([]);
+  });
+
+  it('returns spec IDs where the file is in implementedBy', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    const specEntries: SpecIndexEntry[] = [
+      { type: 'spec', specId: 'FOO-1', title: 'R1', specFile: 'foo.md', requirementCount: 2, implementedBy: ['src/a.ts'], coverageRatio: 1.0 },
+      { type: 'spec', specId: 'FOO-2', title: 'R2', specFile: 'foo.md', requirementCount: 2, implementedBy: ['src/b.ts'], coverageRatio: 1.0 },
+    ];
+    fs.mkdirSync(path.join(tmp, '.github/ai-os/context'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.github/ai-os/context/repo-index.jsonl'),
+      specEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
+      'utf-8',
+    );
+    const results = getSpecForFile(tmp, 'src/a.ts');
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ specId: 'FOO-1', specFile: 'foo.md' });
+  });
+
+  it('returns [] when file has no annotations', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    const specEntries: SpecIndexEntry[] = [
+      { type: 'spec', specId: 'FOO-1', title: 'R1', specFile: 'foo.md', requirementCount: 1, implementedBy: ['src/other.ts'], coverageRatio: 1.0 },
+    ];
+    fs.mkdirSync(path.join(tmp, '.github/ai-os/context'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.github/ai-os/context/repo-index.jsonl'),
+      specEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
+      'utf-8',
+    );
+    expect(getSpecForFile(tmp, 'src/unrelated.ts')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 5.3: Run all spec-traceability tests**
+
+```
+npm run test -- --reporter=verbose src/tests/spec-traceability.test.ts
+```
+
+Expected: ALL tests PASS.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add src/mcp-server/search.ts src/tests/spec-traceability.test.ts
+git commit -m "feat(spec-trace): add validateSpecCoverage and getSpecForFile to search.ts"
+```
+
+---
+
+## Task 6: Register MCP tools in `sdk-server.ts` and `mcp-tools.ts`
+
+**Files:**
+- Modify: `src/mcp-server/sdk-server.ts`
+- Modify: `src/mcp-tools.ts`
+
+- [ ] **Step 6.1: Add imports to `sdk-server.ts`**
+
+Find the existing imports from `./utils.js`. Add `validateSpecCoverage` and `getSpecForFile` to the destructured import list:
+
+```typescript
+import {
+  // ... existing imports ...
+  searchSymbols,
+  getFilePurpose,
+  validateSpecCoverage,
+  getSpecForFile,
+} from './utils.js';
+```
+
+- [ ] **Step 6.2: Register `validate_spec_coverage` (Tool #42)**
+
+Find the closing `// ── Prompts ───` comment in `sdk-server.ts` and insert before it:
+
+```typescript
+  // ── Tool 42: validate_spec_coverage ────────────────────────────────────────
+  server.registerTool(
+    'validate_spec_coverage',
+    {
+      description: 'Reports spec requirement coverage across all spec files in the repo index. Groups requirements by spec file and shows which are annotated with @spec: (implemented) and which are gaps. Requires `ai-os --index` to have run first.',
+      inputSchema: {
+        show_all: z.boolean().optional().describe('Show all requirements including implemented ones (default: false — gaps only).'),
+      },
+    },
+    wrap('validate_spec_coverage', (args) => {
+      const root = getProjectRoot();
+      const showAll = args['show_all'] === true;
+      const groups = validateSpecCoverage(root);
+
+      if (groups.length === 0) {
+        return 'No spec entries found. Run `ai-os --index` first. Ensure spec files exist in docs/superpowers/specs/.';
+      }
+
+      const totalCovered = groups.reduce((sum, g) => sum + g.covered, 0);
+      const totalReqs = groups.reduce((sum, g) => sum + g.total, 0);
+      const overallPct = totalReqs > 0 ? Math.round((totalCovered / totalReqs) * 100) : 0;
+
+      const lines: string[] = ['Spec Coverage Report', '─'.repeat(60)];
+      for (const group of groups) {
+        const pct = Math.round(group.ratio * 100);
+        const icon = pct === 100 ? '✓' : pct === 0 ? '✗' : '⚠';
+        lines.push(
+          `${group.specPrefix.padEnd(14)} ${group.specFile.padEnd(45)} ${group.covered}/${group.total} reqs  ${String(pct).padStart(3)}%  ${icon}`,
+        );
+        if (showAll) {
+          for (const req of group.requirements) {
+            const status = req.implemented ? '  ✓' : '  ✗';
+            lines.push(`  ${status} ${req.specId} — ${req.title}`);
+            if (req.implemented && req.implementedBy.length > 0) {
+              lines.push(`       ↳ ${req.implementedBy.join(', ')}`);
+            }
+          }
+        }
+      }
+      lines.push('─'.repeat(60));
+      lines.push(`Overall: ${totalCovered}/${totalReqs} requirements annotated (${overallPct}%)`);
+      return lines.join('\n');
+    }),
+  );
+
+  // ── Tool 43: get_spec_for_file ──────────────────────────────────────────────
+  server.registerTool(
+    'get_spec_for_file',
+    {
+      description: 'Returns the spec requirements (with IDs and titles) that a given source file implements, based on @spec: annotations in the repo index. Requires `ai-os --index` to have run first.',
+      inputSchema: {
+        path: z.string().describe('Relative path to the source file, e.g. "src/actions/index.ts".'),
+      },
+    },
+    wrap('get_spec_for_file', (args) => {
+      const root = getProjectRoot();
+      const filePath = String(args['path'] ?? '');
+      const results = getSpecForFile(root, filePath);
+
+      if (results.length === 0) {
+        return `No spec annotations found for "${filePath}". Run \`ai-os --index\` first, or add // @spec: ID comments above exported functions.`;
+      }
+
+      const lines = [`${filePath} contributes to:`];
+      for (const r of results) {
+        lines.push(`  ${r.specId.padEnd(20)} — ${r.title}`);
+        lines.push(`  ${''.padEnd(20)}   (${r.specFile})`);
+      }
+      return lines.join('\n');
+    }),
+  );
+```
+
+- [ ] **Step 6.3: Add tool definitions to `mcp-tools.ts`**
+
+Find the closing `];` line of `MCP_TOOL_DEFINITIONS` array. Insert before it:
+
+```typescript
+  // ── Tool #42: Spec Coverage ───────────────────────────────────────────────
+  {
+    name: 'validate_spec_coverage',
+    description: 'Reports spec requirement coverage across all spec files in the repo index. Groups requirements by spec file and shows which are annotated with @spec: (implemented) and which are gaps. Requires `ai-os --index` to have run first.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        show_all: { type: 'boolean', description: 'Show all requirements including implemented ones (default: false — gaps only).' },
+      },
+    },
+    condition: always,
+  },
+  // ── Tool #43: Spec for File ───────────────────────────────────────────────
+  {
+    name: 'get_spec_for_file',
+    description: 'Returns the spec requirements (with IDs and titles) that a given source file implements, based on @spec: annotations in the repo index. Requires `ai-os --index` to have run first.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        path: { type: 'string', description: 'Relative path to the source file, e.g. "src/actions/index.ts".' },
+      },
+      required: ['path'],
+    },
+    condition: always,
+  },
+```
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add src/mcp-server/sdk-server.ts src/mcp-tools.ts
+git commit -m "feat(spec-trace): register validate_spec_coverage and get_spec_for_file MCP tools"
+```
+
+---
+
+## Task 7: Full build, test, version bump, and PR
+
+- [ ] **Step 7.1: Build**
+
+```
+npm run build
+```
+
+Expected: 0 TypeScript errors, 0 warnings.
+
+- [ ] **Step 7.2: Run full test suite**
+
+```
+npm run test
+```
+
+Expected: 614+ tests pass (all existing + new spec-traceability tests). 0 failures.
+
+- [ ] **Step 7.3: Bump version to 0.22.4**
+
+In `package.json`, change:
+
+```json
+"version": "0.22.3"
+```
+
+to:
+
+```json
+"version": "0.22.4"
+```
+
+Run:
+```
+npm install
+```
+
+- [ ] **Step 7.4: Create feature branch and final commit**
+
+```bash
+git checkout -b feat/spec-traceability
+# (all previous commits should already be on this branch if you checked it out at start)
+git add package.json package-lock.json
+git commit -m "chore: bump version to 0.22.4"
+```
+
+- [ ] **Step 7.5: Push and open PR to dev**
+
+```bash
+git push origin feat/spec-traceability
+gh pr create \
+  --base dev \
+  --head feat/spec-traceability \
+  --title "feat: Spec Traceability (RII Phase 2) — v0.22.4" \
+  --body "## Spec Traceability — RII Phase 2
+
+Links spec markdown files to implementing code via \`@spec:\` annotations.
+
+### What's new
+- \`src/generators/spec-parser.ts\` — derives stable spec IDs from filenames + headings
+- \`ai-os --index\` now emits \`SpecIndexEntry\` records in \`repo-index.jsonl\`
+- \`--spec-dir <path>\` CLI flag (default: \`docs/superpowers/specs/\`)
+- MCP tool \`validate_spec_coverage\` — per-spec and overall coverage report
+- MCP tool \`get_spec_for_file\` — shows which specs a file implements
+- 20+ new unit + integration tests; 614+ total tests green
+
+### Usage
+\`\`\`
+# Annotate a function:
+// @spec: SPEC-TRACE-1
+export function parseSpecFiles(...) { ... }
+
+# Index the repo:
+ai-os --index
+
+# Check coverage:
+validate_spec_coverage    # → SPEC-TRACE 0/8 reqs 0% ✗
+\`\`\`"
+```
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] `deriveSpecPrefix("2026-05-25-repo-intelligence-index-design.md")` → `"REPO-INTEL"`
+- [ ] `parseSpecFiles("docs/superpowers/specs/")` returns one entry per H2/H3 heading per file
+- [ ] `parseSpecFiles()` returns `[]` gracefully when directory does not exist
+- [ ] `ai-os --index` on a TypeScript repo with `@spec:` annotations produces `SpecIndexEntry` records
+- [ ] `coverageRatio` is `1.0` for annotated requirements, `0.0` for unannotated ones
+- [ ] `validate_spec_coverage` MCP tool returns a formatted coverage report
+- [ ] `get_spec_for_file("src/actions/index.ts")` returns matching spec IDs
+- [ ] `--spec-dir <path>` CLI flag overrides default spec directory
+- [ ] All 7 language adapters work (annotation detection via existing `parseSpecIds()`)
+- [ ] 0 TypeScript build errors
+- [ ] 614+ total tests pass

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-os",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Portable AI OS — scans any repo and generates optimized GitHub Copilot context, agents, skills, MCP tools, and slash-command prompts",
   "type": "module",
   "engines": {

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -13,11 +13,13 @@ import path from 'node:path';
 import { getExtractorForFile } from '../detectors/symbols.js';
 import { getToolVersion } from '../updater.js';
 import { analyze } from '../analyze.js';
+import { parseSpecFiles } from '../generators/spec-parser.js';
 import type {
   MetaIndexEntry,
   FileIndexEntry,
   SymbolIndexEntry,
   RepoIndexEntry,
+  SpecIndexEntry,
 } from '../types.js';
 
 export interface IndexOptions {
@@ -27,6 +29,8 @@ export interface IndexOptions {
   regenContext?: boolean;
   dryRun?: boolean;
   quiet?: boolean;
+  /** Directory containing spec .md files. Defaults to docs/superpowers/specs/. */
+  specDir?: string;
 }
 
 export interface IndexResult {
@@ -171,7 +175,20 @@ export async function indexRepo(opts: IndexOptions): Promise<IndexResult> {
     symbolCount: symbolEntries.length,
   };
 
-  const allEntries: RepoIndexEntry[] = [meta, ...fileEntries, ...symbolEntries];
+  // Build spec entries — include unchanged symbols too in incremental mode
+  const specDirPath = opts.specDir ?? path.join(cwd, 'docs', 'superpowers', 'specs');
+  const changedPathsForSpec = new Set(fileEntries.map(f => f.path));
+  const existingSymbolsForSpec = incremental && fs.existsSync(outputPath)
+    ? loadExistingEntries(outputPath)
+        .filter((e): e is SymbolIndexEntry =>
+          e.type === 'symbol'
+          && !changedPathsForSpec.has(e.file)
+          && fs.existsSync(path.join(cwd, e.file))
+        )
+    : [];
+  const specEntries = buildSpecEntries(specDirPath, [...symbolEntries, ...existingSymbolsForSpec]);
+
+  const allEntries: RepoIndexEntry[] = [meta, ...fileEntries, ...symbolEntries, ...specEntries];
 
   log(`  📊 ${fileEntries.length} files indexed, ${symbolEntries.length} symbols extracted, ${skippedCount} skipped (unchanged)`);
 
@@ -185,11 +202,11 @@ export async function indexRepo(opts: IndexOptions): Promise<IndexResult> {
       const changedPaths = new Set(fileEntries.map(e => e.path));
       const keptEntries = existing.filter(e => {
         if (e.type === 'meta') return false; // always replace meta
-        if (e.type === 'file') return !changedPaths.has(e.path);
-        if (e.type === 'symbol') return !changedPaths.has(e.file);
-        return true; // keep spec entries
+        if (e.type === 'file') return !changedPaths.has(e.path) && fs.existsSync(path.join(cwd, e.path));
+        if (e.type === 'symbol') return !changedPaths.has(e.file) && fs.existsSync(path.join(cwd, e.file));
+        return false; // spec entries regenerated fresh on every run
       });
-      const merged: RepoIndexEntry[] = [meta, ...fileEntries, ...symbolEntries, ...keptEntries];
+      const merged: RepoIndexEntry[] = [meta, ...fileEntries, ...symbolEntries, ...specEntries, ...keptEntries];
       fs.writeFileSync(outputPath, merged.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
       log(`  ✅ Index updated: ${outputPath}`);
     } else {
@@ -230,6 +247,40 @@ function loadExistingEntries(outputPath: string): RepoIndexEntry[] {
   } catch {
     return [];
   }
+}
+
+function buildSpecEntries(
+  specDirPath: string,
+  allSymbols: SymbolIndexEntry[],
+): SpecIndexEntry[] {
+  const parsed = parseSpecFiles(specDirPath);
+  if (parsed.length === 0) return [];
+
+  // Map specId (normalised uppercase) → set of files that annotate it
+  const implementedByMap = new Map<string, Set<string>>();
+  for (const sym of allSymbols) {
+    const specIds = Array.isArray(sym.specIds) ? sym.specIds : [];
+    for (const specId of specIds) {
+      const normalized = specId.toUpperCase();
+      if (!implementedByMap.has(normalized)) {
+        implementedByMap.set(normalized, new Set<string>());
+      }
+      implementedByMap.get(normalized)!.add(sym.file);
+    }
+  }
+
+  return parsed.map(p => {
+    const implementedBy = [...(implementedByMap.get(p.specId) ?? [])];
+    return {
+      type: 'spec' as const,
+      specId: p.specId,
+      title: p.title,
+      specFile: p.specFile,
+      requirementCount: p.requirementCount,
+      implementedBy,
+      coverageRatio: implementedBy.length > 0 ? 1.0 : 0.0,
+    };
+  });
 }
 
 function inferLanguage(filePath: string): string {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -23,6 +23,7 @@ export interface ParsedArgs {
   editorTargets: EditorTarget[];
   model: ModelTarget;
   incremental: boolean;
+  specDir: string | undefined;
 }
 
 export function parseArgs(): ParsedArgs {
@@ -40,6 +41,7 @@ export function parseArgs(): ParsedArgs {
   let json = false;
   let fullDiff = false;
   let incremental = false;
+  let specDir: string | undefined = undefined;
   const editorTargets: EditorTarget[] = ['vscode'];
   let model: ModelTarget = 'copilot';
 
@@ -87,6 +89,13 @@ export function parseArgs(): ParsedArgs {
       action = 'index';
     } else if (args[i] === '--incremental') {
       incremental = true;
+    } else if (args[i] === '--spec-dir' && args[i + 1]) {
+      specDir = path.resolve(args[i + 1] as string);
+      i++;
+    } else if (args[i] === '--spec-dir' && !args[i + 1]) {
+      throw new Error('--spec-dir requires a path value');
+    } else if (args[i]?.startsWith('--spec-dir=')) {
+      specDir = path.resolve(args[i].slice('--spec-dir='.length));
     } else if (args[i] === '--uninstall') {
       action = 'uninstall';
     } else if (args[i] === '--json') {
@@ -132,5 +141,5 @@ export function parseArgs(): ParsedArgs {
     }
   }
 
-  return { cwd, dryRun, mode, action, prune, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile, json, fullDiff, editorTargets, model, incremental };
+  return { cwd, dryRun, mode, action, prune, verbose, cleanUpdate, regenerateContext, pruneCustomArtifacts, profile, json, fullDiff, editorTargets, model, incremental, specDir };
 }

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -64,6 +64,7 @@ export async function main(): Promise<void> {
       regenContext: args.regenerateContext,
       dryRun: args.dryRun,
       quiet: args.json,
+      specDir: args.specDir,
     });
     return;
   }

--- a/src/generators/spec-parser.ts
+++ b/src/generators/spec-parser.ts
@@ -1,0 +1,131 @@
+/**
+ * spec-parser.ts — Parses spec markdown files and derives stable spec IDs.
+ *
+ * Part of the Repository Intelligence Index (RII) Phase 2.
+ * No external dependencies — regex over file content only.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface ParsedSpec {
+  /** Stable ID, e.g. "REPO-INTEL-3". One per H2/H3 heading. */
+  specId: string;
+  /** Heading text, e.g. "CLI Command: ai-os index". */
+  title: string;
+  /** Basename of spec file, e.g. "2026-05-25-repo-intelligence-index-design.md". */
+  specFile: string;
+  /** Total H2/H3 headings in this file (for context display). */
+  requirementCount: number;
+}
+
+/**
+ * Derives the spec ID prefix from a spec filename.
+ * "2026-05-25-repo-intelligence-index-design.md" → "REPO-INTEL"
+ */
+export function deriveSpecPrefix(filename: string): string {
+  const base = path.basename(filename, '.md');
+  const slug = base
+    .replace(/^\d{4}-\d{2}-\d{2}-/, '')  // strip YYYY-MM-DD-
+    .replace(/-design$/, '');             // strip trailing -design
+  const words = slug.split('-').filter(Boolean);
+
+  // Single-word slugs: use as-is (no truncation)
+  if (words.length === 1) return words[0]!.toUpperCase();
+
+  // Multi-word slugs: abbreviate each of the first two words
+  return words.slice(0, 2).map(abbreviateWord).join('-').toUpperCase();
+}
+
+/**
+ * Truncates a word to a compact abbreviation for use in multi-word spec prefixes.
+ * Words with 6 or fewer characters are returned unchanged.
+ * Longer words are truncated to 5 chars; trailing vowels are stripped unless
+ * the preceding consonant is a soft-sound consonant (c/g before e/i).
+ */
+function abbreviateWord(word: string): string {
+  if (word.length <= 6) return word;
+  const truncated = word.slice(0, 5);
+  const last = truncated[truncated.length - 1]!;
+  if (!'aeiou'.includes(last)) return truncated;
+  const prev = truncated[truncated.length - 2]!;
+  // Preserve soft-sound consonant pairs (ce, ci, ge, gi) to avoid pronunciation shift
+  if ('cg'.includes(prev) && 'ei'.includes(last)) return truncated;
+  return truncated.slice(0, -1);
+}
+
+/**
+ * Parses all .md files in specDir and returns one ParsedSpec per H2/H3 heading per file.
+ * Returns [] gracefully when specDir does not exist.
+ */
+export function parseSpecFiles(specDir: string): ParsedSpec[] {
+  if (!fs.existsSync(specDir)) return [];
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(specDir).filter(f => f.endsWith('.md')).sort();
+  } catch {
+    return [];
+  }
+
+  const results: ParsedSpec[] = [];
+
+  for (const file of files) {
+    let content: string;
+    try {
+      content = fs.readFileSync(path.join(specDir, file), 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const prefix = deriveSpecPrefix(file);
+    const headings = extractHeadings(content);
+
+    for (let i = 0; i < headings.length; i++) {
+      results.push({
+        specId: `${prefix}-${i + 1}`,
+        title: headings[i] ?? '',
+        specFile: file,
+        requirementCount: headings.length,
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Extracts H2/H3 heading text, ignoring content inside code fences (``` or ~~~). */
+/** Extracts H2/H3 heading text, ignoring content inside code fences (``` or ~~~). */
+function extractHeadings(content: string): string[] {
+  const lines = content.split('\n');
+  const headings: string[] = [];
+  let inFence = false;
+  let fenceChar = '';
+  let fenceLen = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (!inFence) {
+      const fenceOpen = /^(`{3,}|~{3,})/.exec(trimmed);
+      if (fenceOpen) {
+        inFence = true;
+        fenceChar = fenceOpen[1]![0]!;
+        fenceLen = fenceOpen[1]!.length;
+        continue;
+      }
+      const m = /^#{2,3}\s+(.+)$/.exec(line);
+      if (m) {
+        const text = m[1]?.trim();
+        if (text) headings.push(text);
+      }
+    } else {
+      const closeRe = new RegExp(`^([${fenceChar}]{${fenceLen},})\\s*$`);
+      if (closeRe.test(trimmed)) {
+        inFence = false;
+        fenceChar = '';
+        fenceLen = 0;
+      }
+    }
+  }
+
+  return headings;
+}

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -13,6 +13,7 @@
  * Requirements: Node.js >= 20
  */
 import type { CopilotClient as CopilotClientClass } from '@github/copilot-sdk';
+import { approveAll } from '@github/copilot-sdk';
 import { getProjectRoot } from './utils.js';
 import { getActiveToolsForProject, type McpToolDefinition } from './tool-definitions.js';
 import { runSdkMcp, createSdkServer } from './sdk-server.js';
@@ -141,7 +142,7 @@ async function main(): Promise<void> {
         return result;
       },
     })),
-    onPermissionRequest: (_req) => ({ kind: 'approved' as const }),
+    onPermissionRequest: approveAll,
   });
 
   process.on('SIGINT', async () => {

--- a/src/mcp-server/sdk-server.ts
+++ b/src/mcp-server/sdk-server.ts
@@ -47,6 +47,8 @@ import {
   classifyIntent,
   searchSymbols,
   getFilePurpose,
+  validateSpecCoverage,
+  getSpecForFile,
 } from './utils.js';
 import { resolveMcpServerVersion } from './shared.js';
 import { detectDrift, formatDriftReport } from '../detectors/drift.js';
@@ -661,6 +663,78 @@ export function createSdkServer(): McpServer {
         result.exports.length > 0 ? `Exports: ${result.exports.join(', ')}` : 'Exports: (none)',
         result.tags.length > 0 ? `Tags: ${result.tags.join(', ')}` : 'Tags: (none)',
       ];
+      return lines.join('\n');
+    }),
+  );
+
+  // ── Tool 42: validate_spec_coverage ────────────────────────────────────────
+  server.registerTool(
+    'validate_spec_coverage',
+    {
+      description: 'Reports spec requirement coverage across all spec files in the repo index. Groups requirements by spec file and shows which are annotated with @spec: (implemented) and which are gaps. Requires `ai-os --index` to have run first.',
+      inputSchema: {
+        show_all: z.boolean().optional().describe('Show all requirements including implemented ones (default: false — gaps only).'),
+      },
+    },
+    wrap('validate_spec_coverage', (args) => {
+      const root = getProjectRoot();
+      const showAll = args['show_all'] === true;
+      const groups = validateSpecCoverage(root);
+
+      if (groups.length === 0) {
+        return 'No spec entries found. Run `ai-os --index` first. Ensure spec files exist in docs/superpowers/specs/.';
+      }
+
+      const totalCovered = groups.reduce((sum, g) => sum + g.covered, 0);
+      const totalReqs = groups.reduce((sum, g) => sum + g.total, 0);
+      const overallPct = totalReqs > 0 ? Math.round((totalCovered / totalReqs) * 100) : 0;
+
+      const lines: string[] = ['Spec Coverage Report', '─'.repeat(60)];
+      for (const group of groups) {
+        const pct = Math.round(group.ratio * 100);
+        const icon = pct === 100 ? '✓' : pct === 0 ? '✗' : '⚠';
+        lines.push(
+          `${group.specPrefix.padEnd(14)} ${group.specFile.padEnd(45)} ${group.covered}/${group.total} reqs  ${String(pct).padStart(3)}%  ${icon}`,
+        );
+        if (showAll) {
+          for (const req of group.requirements) {
+            const status = req.implemented ? '  ✓' : '  ✗';
+            lines.push(`  ${status} ${req.specId} — ${req.title}`);
+            if (req.implemented && req.implementedBy.length > 0) {
+              lines.push(`       ↳ ${req.implementedBy.join(', ')}`);
+            }
+          }
+        }
+      }
+      lines.push('─'.repeat(60));
+      lines.push(`Overall: ${totalCovered}/${totalReqs} requirements annotated (${overallPct}%)`);
+      return lines.join('\n');
+    }),
+  );
+
+  // ── Tool 43: get_spec_for_file ──────────────────────────────────────────────
+  server.registerTool(
+    'get_spec_for_file',
+    {
+      description: 'Returns the spec requirements (with IDs and titles) that a given source file implements, based on @spec: annotations in the repo index. Requires `ai-os --index` to have run first.',
+      inputSchema: {
+        path: z.string().describe('Relative path to the source file, e.g. "src/actions/index.ts".'),
+      },
+    },
+    wrap('get_spec_for_file', (args) => {
+      const root = getProjectRoot();
+      const filePath = String(args['path'] ?? '');
+      const results = getSpecForFile(root, filePath);
+
+      if (results.length === 0) {
+        return `No spec annotations found for "${filePath}". Run \`ai-os --index\` first, or add // @spec: ID comments above exported functions.`;
+      }
+
+      const lines = [`${filePath} contributes to:`];
+      for (const r of results) {
+        lines.push(`  ${r.specId.padEnd(20)} — ${r.title}`);
+        lines.push(`  ${''.padEnd(20)}   (${r.specFile})`);
+      }
       return lines.join('\n');
     }),
   );

--- a/src/mcp-server/search.ts
+++ b/src/mcp-server/search.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { ROOT } from './shared.js';
 import type { IntentType, IntentResult, BoostPromptResult, ClarifyingQuestion } from '../types.js';
+import { deriveSpecPrefix } from '../generators/spec-parser.js';
 
 export function searchFiles(query: string, filePattern?: string, caseSensitive = false): string {
   try {
@@ -416,3 +417,108 @@ export function getFilePurpose(
   return null;
 }
 
+export interface SpecCoverageGroup {
+  specPrefix: string;
+  specFile: string;
+  covered: number;
+  total: number;
+  ratio: number;
+  requirements: Array<{
+    specId: string;
+    title: string;
+    implemented: boolean;
+    implementedBy: string[];
+  }>;
+}
+
+/**
+ * Groups SpecIndexEntry records by spec file and computes per-file coverage.
+ * Falls back gracefully when no index file exists.
+ */
+export function validateSpecCoverage(projectRoot: string): SpecCoverageGroup[] {
+  const raw = readRepoIndex(projectRoot);
+  if (!raw) return [];
+
+  const entries = parseIndexEntries(raw);
+  const specEntries = entries.filter(e => e.type === 'spec');
+  if (specEntries.length === 0) return [];
+
+  const byFile = new Map<string, typeof specEntries>();
+  for (const e of specEntries) {
+    const file = (e['specFile'] as string | undefined) ?? 'unknown';
+    if (!byFile.has(file)) byFile.set(file, []);
+    byFile.get(file)!.push(e);
+  }
+
+  const results: SpecCoverageGroup[] = [];
+  for (const [specFile, reqs] of byFile) {
+    const requirements = reqs.map(e => {
+      const rawBy = e['implementedBy'];
+      const implementedBy: string[] = Array.isArray(rawBy)
+        ? (rawBy as unknown[]).filter((x): x is string => typeof x === 'string')
+        : [];
+      return {
+        specId: (e['specId'] as string | undefined) ?? '',
+        title: (e['title'] as string | undefined) ?? '',
+        implemented: implementedBy.length > 0,
+        implementedBy,
+      };
+    });
+    const covered = requirements.filter(r => r.implemented).length;
+    results.push({
+      specPrefix: deriveSpecPrefix(specFile),
+      specFile,
+      covered,
+      total: requirements.length,
+      ratio: requirements.length > 0 ? covered / requirements.length : 0,
+      requirements,
+    });
+  }
+
+  return results.sort((a, b) => a.specFile.localeCompare(b.specFile));
+}
+
+export interface SpecForFileEntry {
+  specId: string;
+  title: string;
+  specFile: string;
+}
+
+/**
+ * Returns spec requirements implemented by a given file path.
+ * Falls back gracefully when no index file exists.
+ * Accepts both relative and absolute paths.
+ */
+export function getSpecForFile(projectRoot: string, filePath: string): SpecForFileEntry[] {
+  const raw = readRepoIndex(projectRoot);
+  if (!raw) return [];
+
+  // Normalise to forward slashes; strip projectRoot prefix if absolute path supplied
+  const root = projectRoot.replace(/\\/g, '/').replace(/\/$/, '');
+  let normalised = filePath.replace(/\\/g, '/');
+  if (normalised.startsWith(root + '/')) normalised = normalised.slice(root.length + 1);
+
+  const entries = parseIndexEntries(raw);
+  const results: SpecForFileEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.type !== 'spec') continue;
+    const rawBy = entry['implementedBy'];
+    const implementedBy: string[] = Array.isArray(rawBy)
+      ? (rawBy as unknown[]).filter((x): x is string => typeof x === 'string')
+      : [];
+    const isImplemented = implementedBy.some(f => {
+      const fn = f.replace(/\\/g, '/');
+      return fn === normalised || fn.endsWith(`/${normalised}`);
+    });
+    if (isImplemented) {
+      results.push({
+        specId: (entry['specId'] as string | undefined) ?? '',
+        title: (entry['title'] as string | undefined) ?? '',
+        specFile: (entry['specFile'] as string | undefined) ?? '',
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -448,6 +448,31 @@ export const MCP_TOOL_DEFINITIONS: McpToolDefinition[] = [
     },
     condition: always,
   },
+  // ── Tool #42: Spec Coverage ───────────────────────────────────────────────
+  {
+    name: 'validate_spec_coverage',
+    description: 'Reports spec requirement coverage across all spec files in the repo index. Groups requirements by spec file and shows which are annotated with @spec: (implemented) and which are gaps. Requires `ai-os --index` to have run first.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        show_all: { type: 'boolean', description: 'Show all requirements including implemented ones (default: false — gaps only).' },
+      },
+    },
+    condition: always,
+  },
+  // ── Tool #43: Spec for File ───────────────────────────────────────────────
+  {
+    name: 'get_spec_for_file',
+    description: 'Returns the spec requirements (with IDs and titles) that a given source file implements, based on @spec: annotations in the repo index. Requires `ai-os --index` to have run first.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        path: { type: 'string', description: 'Relative path to the source file, e.g. "src/actions/index.ts".' },
+      },
+      required: ['path'],
+    },
+    condition: always,
+  },
 ];
 
 export function getMcpToolsForStack(stack: DetectedStack): Array<Omit<McpToolDefinition, 'condition'>> {

--- a/src/tests/spec-traceability.test.ts
+++ b/src/tests/spec-traceability.test.ts
@@ -1,0 +1,90 @@
+// src/tests/spec-traceability.test.ts
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { deriveSpecPrefix, parseSpecFiles } from '../generators/spec-parser.js';
+import type { SpecIndexEntry, RepoIndexEntry } from '../types.js';
+
+function makeTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'spec-trace-test-'));
+}
+function write(dir: string, rel: string, content: string): void {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf-8');
+}
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+// ── deriveSpecPrefix ──────────────────────────────────────────────────────────
+
+describe('deriveSpecPrefix', () => {
+  it.each([
+    ['2026-05-25-repo-intelligence-index-design.md', 'REPO-INTEL'],
+    ['2026-05-11-a2a-orchestrator-design.md', 'A2A-ORCH'],
+    ['2026-05-25-prompt-booster-design.md', 'PROMPT-BOOST'],
+    ['2026-05-27-spec-traceability-design.md', 'SPEC-TRACE'],
+    ['2026-01-01-single-design.md', 'SINGLE'],
+    ['plain.md', 'PLAIN'],
+  ])('%s → %s', (input: string, expected: string) => {
+    expect(deriveSpecPrefix(input)).toBe(expected);
+  });
+});
+
+// ── parseSpecFiles ────────────────────────────────────────────────────────────
+
+describe('parseSpecFiles', () => {
+  it('returns [] when specDir does not exist', () => {
+    expect(parseSpecFiles('/this/path/does/not/exist')).toEqual([]);
+  });
+
+  it('returns one entry per H2/H3 heading in document order', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-01-my-feature-design.md', [
+      '# My Feature',
+      '## Overview',
+      '## API Shape',
+      '### Sub-section',
+      '#### H4 is ignored',
+    ].join('\n'));
+    const results = parseSpecFiles(path.join(tmp, 'specs'));
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({ specId: 'MY-FEAT-1', title: 'Overview', requirementCount: 3 });
+    expect(results[1]).toMatchObject({ specId: 'MY-FEAT-2', title: 'API Shape', requirementCount: 3 });
+    expect(results[2]).toMatchObject({ specId: 'MY-FEAT-3', title: 'Sub-section', requirementCount: 3 });
+  });
+
+  it('ignores headings inside code fences', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-01-example-design.md', [
+      '## Real Heading',
+      '```',
+      '## Fake Heading inside fence',
+      '```',
+      '## Another Real Heading',
+    ].join('\n'));
+    const results = parseSpecFiles(path.join(tmp, 'specs'));
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ specId: 'EXAMPLE-1', title: 'Real Heading' });
+    expect(results[1]).toMatchObject({ specId: 'EXAMPLE-2', title: 'Another Real Heading' });
+  });
+
+  it('processes multiple spec files sorted alphabetically by filename', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-02-beta-design.md', '## Beta Req\n## Beta Req 2');
+    write(tmp, 'specs/2026-01-01-alpha-design.md', '## Alpha Req');
+    const results = parseSpecFiles(path.join(tmp, 'specs'));
+    expect(results[0]).toMatchObject({ specId: 'ALPHA-1', specFile: '2026-01-01-alpha-design.md' });
+    expect(results[1]).toMatchObject({ specId: 'BETA-1', specFile: '2026-01-02-beta-design.md' });
+    expect(results[2]).toMatchObject({ specId: 'BETA-2', specFile: '2026-01-02-beta-design.md' });
+  });
+
+  it('returns [] for a spec file with no H2/H3 headings', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'specs/2026-01-01-empty-design.md', '# Only H1\n#### Only H4');
+    expect(parseSpecFiles(path.join(tmp, 'specs'))).toHaveLength(0);
+  });
+});

--- a/src/tests/spec-traceability.test.ts
+++ b/src/tests/spec-traceability.test.ts
@@ -150,3 +150,91 @@ describe('indexRepo — SpecIndexEntry emission', () => {
     expect(specs[0]!.implementedBy).toContain('src/index.ts');
   });
 });
+
+// ── validateSpecCoverage ──────────────────────────────────────────────────────
+
+import { validateSpecCoverage, getSpecForFile } from '../mcp-server/search.js';
+
+describe('validateSpecCoverage', () => {
+  it('returns [] when no index file exists', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    expect(validateSpecCoverage(tmp)).toEqual([]);
+  });
+
+  it('groups spec entries by specFile and computes coverage', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    const specEntries: SpecIndexEntry[] = [
+      { type: 'spec', specId: 'FOO-1', title: 'R1', specFile: 'foo.md', requirementCount: 2, implementedBy: ['src/a.ts'], coverageRatio: 1.0 },
+      { type: 'spec', specId: 'FOO-2', title: 'R2', specFile: 'foo.md', requirementCount: 2, implementedBy: [], coverageRatio: 0.0 },
+    ];
+    fs.mkdirSync(path.join(tmp, '.github/ai-os/context'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.github/ai-os/context/repo-index.jsonl'),
+      specEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
+      'utf-8',
+    );
+    const results = validateSpecCoverage(tmp);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ specFile: 'foo.md', covered: 1, total: 2 });
+    expect(results[0]!.ratio).toBeCloseTo(0.5);
+    expect(results[0]!.requirements[0]).toMatchObject({ specId: 'FOO-1', implemented: true });
+    expect(results[0]!.requirements[1]).toMatchObject({ specId: 'FOO-2', implemented: false });
+  });
+});
+
+// ── getSpecForFile ────────────────────────────────────────────────────────────
+
+describe('getSpecForFile', () => {
+  it('returns [] when no index file exists', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    expect(getSpecForFile(tmp, 'src/a.ts')).toEqual([]);
+  });
+
+  it('returns spec IDs where the file is in implementedBy', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    const specEntries: SpecIndexEntry[] = [
+      { type: 'spec', specId: 'FOO-1', title: 'R1', specFile: 'foo.md', requirementCount: 2, implementedBy: ['src/a.ts'], coverageRatio: 1.0 },
+      { type: 'spec', specId: 'FOO-2', title: 'R2', specFile: 'foo.md', requirementCount: 2, implementedBy: ['src/b.ts'], coverageRatio: 1.0 },
+    ];
+    fs.mkdirSync(path.join(tmp, '.github/ai-os/context'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.github/ai-os/context/repo-index.jsonl'),
+      specEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
+      'utf-8',
+    );
+    const results = getSpecForFile(tmp, 'src/a.ts');
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ specId: 'FOO-1', specFile: 'foo.md' });
+  });
+
+  it('matches when absolute path is passed', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    const specEntries: SpecIndexEntry[] = [
+      { type: 'spec', specId: 'FOO-1', title: 'R1', specFile: 'foo.md', requirementCount: 1, implementedBy: ['src/a.ts'], coverageRatio: 1.0 },
+    ];
+    fs.mkdirSync(path.join(tmp, '.github/ai-os/context'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.github/ai-os/context/repo-index.jsonl'),
+      specEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
+      'utf-8',
+    );
+    const absPath = path.join(tmp, 'src', 'a.ts');
+    const results = getSpecForFile(tmp, absPath);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ specId: 'FOO-1' });
+  });
+
+  it('returns [] when file has no annotations', () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    const specEntries: SpecIndexEntry[] = [
+      { type: 'spec', specId: 'FOO-1', title: 'R1', specFile: 'foo.md', requirementCount: 1, implementedBy: ['src/other.ts'], coverageRatio: 1.0 },
+    ];
+    fs.mkdirSync(path.join(tmp, '.github/ai-os/context'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.github/ai-os/context/repo-index.jsonl'),
+      specEntries.map(e => JSON.stringify(e)).join('\n') + '\n',
+      'utf-8',
+    );
+    expect(getSpecForFile(tmp, 'src/unrelated.ts')).toEqual([]);
+  });
+});

--- a/src/tests/spec-traceability.test.ts
+++ b/src/tests/spec-traceability.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { deriveSpecPrefix, parseSpecFiles } from '../generators/spec-parser.js';
+import { indexRepo } from '../actions/index.js';
 import type { SpecIndexEntry, RepoIndexEntry } from '../types.js';
 
 function makeTmp(): string {
@@ -18,6 +19,12 @@ const dirs: string[] = [];
 afterEach(() => {
   for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
 });
+
+function readJsonl(p: string): RepoIndexEntry[] {
+  return fs.readFileSync(p, 'utf-8')
+    .split('\n').filter(Boolean)
+    .map(l => JSON.parse(l) as RepoIndexEntry);
+}
 
 // ── deriveSpecPrefix ──────────────────────────────────────────────────────────
 
@@ -86,5 +93,60 @@ describe('parseSpecFiles', () => {
     const tmp = makeTmp(); dirs.push(tmp);
     write(tmp, 'specs/2026-01-01-empty-design.md', '# Only H1\n#### Only H4');
     expect(parseSpecFiles(path.join(tmp, 'specs'))).toHaveLength(0);
+  });
+});
+
+// ── indexRepo integration ─────────────────────────────────────────────────────
+
+describe('indexRepo — SpecIndexEntry emission', () => {
+  it('emits SpecIndexEntry records when spec files and annotations exist', async () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'src/index.ts', [
+      '// @spec: MY-FEAT-1',
+      'export function doThing(): void {}',
+    ].join('\n'));
+    write(tmp, 'docs/superpowers/specs/2026-01-01-my-feature-design.md', [
+      '## Overview',
+      '## Detail',
+    ].join('\n'));
+
+    const result = await indexRepo({ cwd: tmp, quiet: true });
+    const entries = readJsonl(result.outputPath);
+    const specs = entries.filter((e): e is SpecIndexEntry => e.type === 'spec');
+
+    expect(specs).toHaveLength(2);
+
+    const covered = specs.find(s => s.specId === 'MY-FEAT-1');
+    expect(covered).toBeDefined();
+    expect(covered!.implementedBy).toContain('src/index.ts');
+    expect(covered!.coverageRatio).toBe(1.0);
+
+    const uncovered = specs.find(s => s.specId === 'MY-FEAT-2');
+    expect(uncovered).toBeDefined();
+    expect(uncovered!.implementedBy).toHaveLength(0);
+    expect(uncovered!.coverageRatio).toBe(0.0);
+  });
+
+  it('emits no spec entries when spec dir is absent', async () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'src/index.ts', 'export function foo() {}');
+    const result = await indexRepo({ cwd: tmp, quiet: true });
+    const entries = readJsonl(result.outputPath);
+    expect(entries.filter(e => e.type === 'spec')).toHaveLength(0);
+  });
+
+  it('uses custom specDir when provided', async () => {
+    const tmp = makeTmp(); dirs.push(tmp);
+    write(tmp, 'src/index.ts', '// @spec: FOO-1\nexport function foo() {}');
+    write(tmp, 'custom/2026-01-01-foo-design.md', '## Req One');
+    const result = await indexRepo({
+      cwd: tmp,
+      quiet: true,
+      specDir: path.join(tmp, 'custom'),
+    });
+    const entries = readJsonl(result.outputPath);
+    const specs = entries.filter((e): e is SpecIndexEntry => e.type === 'spec');
+    expect(specs).toHaveLength(1);
+    expect(specs[0]!.implementedBy).toContain('src/index.ts');
   });
 });


### PR DESCRIPTION
## Spec Traceability — RII Phase 2

Adds \@spec:\ annotation-based requirement traceability to the ai-os indexer.

### New features
- **\spec-parser.ts\** — parses spec Markdown files (H2/H3 headings), derives spec IDs from filenames (CommonMark-compliant fence handling)
- **\--spec-dir\ CLI flag** — override the default \docs/superpowers/specs/\ location
- **\SpecIndexEntry\ emission** in \indexRepo()\ — links \@spec: ID\ annotations to spec requirements
- **MCP Tool #42: \alidate_spec_coverage\** — coverage report grouped by spec file with gap analysis
- **MCP Tool #43: \get_spec_for_file\** — lists spec requirements a source file contributes to

### Bug fixes (incremental indexing)
- Deleted files no longer remain in the incremental index (\keptEntries\ + \xistingSymbolsForSpec\ now check \s.existsSync\)

### Tests
- 20 tests added (\src/tests/spec-traceability.test.ts\)
- Full suite: **634/634 passing**

### Commits
- \	est(spec-trace):\ failing tests for spec-parser module
- \eat(spec-trace):\ spec-parser.ts module (CommonMark-compliant)
- \eat(spec-trace):\ add --spec-dir CLI flag
- \eat(spec-trace):\ emit SpecIndexEntry records in indexRepo pipeline
- \eat(spec-trace):\ add validateSpecCoverage and getSpecForFile to search.ts
- \eat(spec-trace):\ register validate_spec_coverage and get_spec_for_file MCP tools
- \chore:\ bump version to 0.22.4