### PR TITLE
fix(recommendations): skip redundant global skill installs when local skills exist

### DIFF
--- a/src/actions/apply.ts
+++ b/src/actions/apply.ts
@@ -592,11 +592,25 @@ function printSuperpowersPluginSetup(): void {
  * Idempotent: reads skills-lock.json and skips skills already installed.
  * Gives every AI OS project the core agentic development methodology out of the box.
  */
-function autoInstallSuperpowers(stack: ReturnType<typeof analyze>, skillsLockPath: string): void {
+function autoInstallSuperpowers(stack: ReturnType<typeof analyze>, skillsLockPath: string, cwd: string): void {
   const recs = collectRecommendations(stack);
   const allSuperpowers = recs.universalSkills.filter(s => s.source === 'obra/superpowers');
 
   if (allSuperpowers.length === 0) return;
+
+  // Skills already copied locally by AI OS — global install is redundant for these
+  const localSkillsDir = path.join(cwd, '.github', 'copilot', 'skills');
+  const locallyInstalled = new Set(
+    allSuperpowers
+      .filter(s => fs.existsSync(path.join(localSkillsDir, `${s.name}.md`)))
+      .map(s => s.name.toLowerCase())
+  );
+
+  if (locallyInstalled.size > 0) {
+    console.log(`  🦸 ${locallyInstalled.size} Superpowers skill(s) already available as local project skills in .github/copilot/skills/ — skipping global install.`);
+    console.log('     (Global install via `npx -y skills add` is only needed for other agents that don\'t read project-local skills.)');
+    console.log('');
+  }
 
   // Read installed skills from lock file to skip already-installed ones
   let installedSet = new Set<string>();
@@ -610,8 +624,11 @@ function autoInstallSuperpowers(stack: ReturnType<typeof analyze>, skillsLockPat
     // Lock file missing — treat all as uninstalled
   }
 
-  const toInstall = allSuperpowers.filter(s => !installedSet.has(s.name.toLowerCase()));
-  const alreadyInstalled = allSuperpowers.length - toInstall.length;
+  // Skip skills that are locally available or already in the lock file
+  const toInstall = allSuperpowers.filter(
+    s => !installedSet.has(s.name.toLowerCase()) && !locallyInstalled.has(s.name.toLowerCase())
+  );
+  const alreadyInstalled = allSuperpowers.length - toInstall.length - locallyInstalled.size;
 
   if (toInstall.length === 0) {
     console.log('  🦸 All Superpowers skills already installed.');
@@ -1076,7 +1093,7 @@ export async function runApply(args: ParsedArgs): Promise<void> {
   const isFirstInstall = updateStatus.isFirstInstall;
   if (!dryRun && isFirstInstall) {
     const spLockPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'skills-lock.json');
-    autoInstallSuperpowers(stack, spLockPath);
+    autoInstallSuperpowers(stack, spLockPath, cwd);
   }
 
   // ── Agent-flow setup prompt ──────────────────────────────────────────────

--- a/src/recommendations/index.ts
+++ b/src/recommendations/index.ts
@@ -189,6 +189,15 @@ function generateRecommendationsDoc(stack: DetectedStack, collected: CollectedRe
     for (const plugin of collected.pluginInstalls) {
       lines.push(`## ${plugin.name}`, '');
       lines.push(`> ${plugin.description}`, '');
+
+      // Note: AI OS repos already have these skills as local project copies
+      if (plugin.skillSource) {
+        lines.push('');
+        lines.push('> **Note for AI OS repos:** If this repository has AI OS installed, the skills listed below are already available as project-local copies in `.github/copilot/skills/`.');
+        lines.push('> Global install via the commands below is only needed for agents that do **not** read project-local skills (e.g. Cursor, Augment) or for cross-repo use.');
+        lines.push('');
+      }
+
       lines.push('**Install in your coding agent:**', '');
       lines.push('```bash');
       for (const step of plugin.steps) {


### PR DESCRIPTION
Fixes #225

## Changes
- utoInstallSuperpowers(): check .github/copilot/skills/<name>.md and skip global install for skills already present locally
- generateRecommendationsDoc(): add note in Superpowers section that local project skills cover these installs for AI OS repos

## Why
AI OS already copies Superpowers skills to \.github/copilot/skills/\. GitHub Copilot CLI reads project-local skills from this directory — so running \
px -y skills add obra/superpowers@<skill> -g\ is redundant and can conflict with local versions.