### PR TITLE
chore: bump self-applied ai-os version to 0.24.0

### DIFF
--- a/.github/ai-os/config.json
+++ b/.github/ai-os/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.23.0",
+  "version": "0.24.0",
   "installedAt": "2026-05-28T07:03:44.917Z",
   "projectName": "ai-os",
   "primaryLanguage": "TypeScript",


### PR DESCRIPTION
The dogfood config `.github/ai-os/config.json` lagged at `0.23.0` while `package.json` is `0.24.0`. The weekly **AI OS Update Check** workflow compares those two and kept opening "update available" issues (#265, #257). Aligning the recorded version stops the false notifications.

Closes #265
Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)