### PR TITLE
fix(ci): restore @emnapi optional-dep records in engine lockfile

### DIFF
--- a/engine/package-lock.json
+++ b/engine/package-lock.json
@@ -4489,6 +4489,29 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0",
+        "@emnapi/wasi-threads": "1.2.1"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     }
   }
 }


### PR DESCRIPTION
The `AI OS — Repository Index` workflow has been failing on `master` and `dev` since the `master→dev` reconciliation merge. Root cause: that merge regenerated `engine/package-lock.json` with a newer npm that pruned the `node_modules/@emnapi/{core,runtime}` package records. CI's `npm ci` then fails with `EUSAGE — Missing @emnapi/core@1.10.0 from lock file`, because `engine/package.json` declares them as `optionalDependencies`.

Same regression that commit `3d6acd0` previously fixed. Restored both records (version unchanged at 1.10.0).

**Verified:** `npm ci --dry-run` in `engine/` exits 0 (adds the 2 packages). 23-line insertion, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)