### PR TITLE
fix(ci): make refresh-existing non-interactive-safe (unblock validate-full)

### DIFF
--- a/engine/src/cli/dispatch.ts
+++ b/engine/src/cli/dispatch.ts
@@ -100,6 +100,7 @@ export async function main(): Promise<void> {
     action !== 'init' &&
     !args.json &&
     !args.dryRun &&
+    process.stdin.isTTY &&
     args.model === 'copilot' &&
     (args.mode === 'refresh-existing' || args.mode === 'update' || action === 'apply')
   ) {


### PR DESCRIPTION
**Fixes the red `Cortex Validate → validate-full` on dev/master.**

Root cause: the Claude-migration prompt (`dispatch.ts`) gated on model/mode/config but **not on interactivity**, so in non-interactive/CI runs `--refresh-existing` blocked on `🤖 Add Claude Code support? [y/N]` before printing its next-steps — failing every `checkRefreshSafety` regression check. `validate-full` only runs on push (not PRs), so PR #275's green checks never exercised it.

Fix: only show the prompt when `process.stdin.isTTY` (interactive terminal). CI/regression keep the copilot default and proceed normally.

**Verification:** regression suite **357/357 pass** (was failing 6×6 fixtures); 684 unit tests green.