### PR TITLE
chore(release): v0.25.0 — AI-agnostic core + BrainStore + semantic search

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   workflow_run:
-    workflows: ["AI OS Validate"]
+    workflows: ["Cortex Validate"]
     types: [completed]
     branches: [master]
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Skip direct push release
-        run: echo "Release is gated by AI OS Validate workflow_run; push event is a no-op."
+        run: echo "Release is gated by Cortex Validate workflow_run; push event is a no-op."
 
   release:
     # Only release when: manual dispatch OR validate succeeded AND ran on the master branch

--- a/engine/dist/bundle-manifest.json
+++ b/engine/dist/bundle-manifest.json
@@ -1,6 +1,6 @@
 {
-  "bundledAt": "2026-06-26T04:35:29.002Z",
-  "sourceVersion": "0.24.0",
+  "bundledAt": "2026-06-26T07:40:42.290Z",
+  "sourceVersion": "0.25.0",
   "entryPoint": "server.js",
   "sha256": "f8ddf2b273e6136533e35296abd094a284fcec13df792c6a92b480f1d7699ebc",
   "node": ">=20"

--- a/engine/package-lock.json
+++ b/engine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cortex",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cortex",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/engine/package.json
+++ b/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Cortex — portable AI-assistant context engine that scans any repo and generates context, agents, skills, MCP tools, and slash-command prompts",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
   "name": "cortex",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Cortex — portable AI-assistant context engine. Engine package lives in ./engine.",
   "type": "module",
-  "engines": { "node": ">=22.0.0" },
-  "bin": { "cortex": "./engine/bundle/generate.js" },
-  "files": ["engine/bundle", "engine/src/templates", "engine/README.md"]
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "bin": {
+    "cortex": "./engine/bundle/generate.js"
+  },
+  "files": [
+    "engine/bundle",
+    "engine/src/templates",
+    "engine/README.md"
+  ]
 }


### PR DESCRIPTION
Release prep for v0.25.0 (this cycle's feature set).

- Bump root + engine + lockfile → 0.25.0
- **Fix the broken Automated Release trigger** — it listened for the old `"AI OS Validate"` workflow name; renamed to `"Cortex Validate"` (broke in #275), so releases stopped auto-firing on master
- Regenerate version-stamped bundle manifest

After this lands on `dev`, `dev` → `master` will trigger Cortex Validate → Automated Release → tag `v0.25.0` + GitHub Release with SLSA bundle attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)