### PR TITLE
fix(cortex-init): robust non-TTY input + node/bun CI matrix

### DIFF
--- a/.github/workflows/cortex-init-test.yml
+++ b/.github/workflows/cortex-init-test.yml
@@ -12,14 +12,23 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [node, bun]
+    name: smoke (${{ matrix.runtime }})
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
+        if: matrix.runtime == 'node'
         with:
           node-version: 20
 
-      - name: Run cortex-init against a dummy repo
+      - uses: oven-sh/setup-bun@v2
+        if: matrix.runtime == 'bun'
+
+      - name: Run cortex-init against a dummy repo (${{ matrix.runtime }})
         run: |
           set -euo pipefail
           SCRIPT="$PWD/tools/cortex-init.mjs"
@@ -37,20 +46,20 @@ jobs:
           JSON
           mkdir -p src public
 
-          # answer the wizard prompts: name, purpose, convention, agents
-          printf 'DummyApp\nA test project\nNo console.logs in committed code\nall\n' | node "$SCRIPT"
+          # answer the wizard prompts via stdin: name, purpose, convention, agents
+          printf 'DummyApp\nA test project\nNo console.logs in committed code\nall\n' | ${{ matrix.runtime }} "$SCRIPT"
 
           echo "=== generated tree ==="
           find . -type f -not -name package.json | sort
 
-      - name: Assert the brain files exist
+      - name: Assert the brain files exist (${{ matrix.runtime }})
         run: |
           set -euo pipefail
           # Regenerate in a fresh dir and assert the output here (cheap + deterministic).
           SCRIPT="$PWD/tools/cortex-init.mjs"
           DIR="$(mktemp -d)"; cd "$DIR"
           printf '{ "name": "dummy", "dependencies": { "react": "^18" } }' > package.json
-          printf 'DummyApp\nA test project\n\nall\n' | node "$SCRIPT" >/dev/null
+          printf 'DummyApp\nA test project\n\nall\n' | ${{ matrix.runtime }} "$SCRIPT" >/dev/null
 
           fail=0
           for f in \
@@ -69,4 +78,18 @@ jobs:
           # AGENTS.md must mention the detected framework
           grep -q "React" AGENTS.md || { echo "AGENTS.md missing detected stack"; fail=1; }
 
+          exit $fail
+
+      - name: Assert non-interactive --yes works (${{ matrix.runtime }})
+        run: |
+          set -euo pipefail
+          # No stdin at all: --yes must accept detected defaults and still write the brain.
+          SCRIPT="$PWD/tools/cortex-init.mjs"
+          DIR="$(mktemp -d)"; cd "$DIR"
+          printf '{ "name": "yesapp", "dependencies": { "next": "^14" } }' > package.json
+          ${{ matrix.runtime }} "$SCRIPT" --yes >/dev/null
+
+          fail=0
+          [ -f AGENTS.md ] || { echo "MISS AGENTS.md"; fail=1; }
+          grep -q "Next.js" AGENTS.md || { echo "AGENTS.md missing detected stack (Next.js)"; fail=1; }
           exit $fail

--- a/README.md
+++ b/README.md
@@ -35,14 +35,25 @@ itself stays shareable and forkable.
 ## Give any repo a codebase brain (one-liner)
 
 Run this **inside any project repo** — it scans the code, asks a few questions, and writes an
-`AGENTS.md` + agent shims (Claude/Gemini/Copilot/Cursor) + dev-cycle skills into that repo:
+`AGENTS.md` + agent shims (Claude/Gemini/Copilot/Cursor) + dev-cycle skills into that repo.
+Works in any shell (bash, zsh, gitbash, PowerShell) and under either runtime:
 
 ```bash
-npx github:marinvch/ai-os
+npx  github:marinvch/ai-os     # Node
+bunx github:marinvch/ai-os     # Bun
 ```
 
-Zero dependencies, nothing to install. Review the generated `AGENTS.md`, then commit it so the
-whole team's agents share the same project knowledge. Source: `tools/cortex-init.mjs`.
+Prefer non-interactive (CI, scripts)? Pipe the four answers — name, what-it-does, key rule,
+agents — or take all detected defaults with `--yes`:
+
+```bash
+printf 'MyApp\nWhat it does\nKey rule\nall\n' | npx github:marinvch/ai-os
+npx github:marinvch/ai-os --yes
+```
+
+Zero dependencies, nothing to install. It detects your package manager (npm/pnpm/yarn/bun)
+automatically. Review the generated `AGENTS.md`, then commit it so the whole team's agents share
+the same project knowledge. Source: `tools/cortex-init.mjs`.
 
 ## Skills (rituals)
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,25 +4,48 @@ A tiny, zero-dependency wizard that installs a **codebase brain** into any repo 
 experience: run one command, answer a few questions, and the repo gets an `AGENTS.md` + agent
 shims (Claude/Gemini/Copilot/Cursor) + dev-cycle skills. No heavy engine, no Node packages.
 
+Runs in any shell (bash, zsh, gitbash, PowerShell) under either runtime — swap `node` for `bun`
+if that's what you have.
+
 ## Run it (3 ways)
 
 **1. Direct (works immediately, nothing to install):**
+```bash
+# from inside the target repo — bash / zsh / gitbash
+node /path/to/ai-os/tools/cortex-init.mjs
+bun  /path/to/ai-os/tools/cortex-init.mjs   # if you use Bun instead of Node
+```
 ```powershell
-# from inside the target repo
+# PowerShell
 node D:\Projects\Personal\ai-os\tools\cortex-init.mjs
 ```
 
-**2. As a global command (type `cortex-init` in any repo):**
+**2. As a global command (type `cortex` in any repo):**
 ```powershell
-# one-time install
+# one-time install (installs the `cortex` command)
 npm install -g D:\Projects\Personal\ai-os\tools
 # then, inside any repo:
-cortex-init
+cortex
 ```
 
-**3. As `npx cortex-init` (after you publish it):**
-Publish this folder to npm (`npm publish`) or point npx at your GitHub repo
-(`npx github:marinvch/ai-os` once a root bin is wired). Until then, use option 1 or 2.
+**3. As `npx` / `bunx` from GitHub (no install, nothing to publish):**
+```bash
+# from inside the target repo
+npx  github:marinvch/ai-os     # Node
+bunx github:marinvch/ai-os     # Bun
+```
+The repo root wires the `cortex` bin to this script, so this works today against the
+public repo. To also publish to npm as `cortex`, run `npm publish` from the repo root.
+
+## Non-interactive (CI, scripts, no TTY)
+
+In a real terminal the wizard prompts you. With no TTY it reads answers from stdin (one per
+line: name, what-it-does, key rule, agents) — blank lines fall back to detected defaults. Or
+pass `--yes` to accept every default with no input at all:
+```bash
+printf 'MyApp\nWhat it does\nKey rule\nall\n' | node tools/cortex-init.mjs
+node tools/cortex-init.mjs --yes
+```
 
 ## What it does
 1. Scans the repo (package.json, lockfile, configs, folders) to detect stack, scripts, conventions.

--- a/tools/cortex-init.mjs
+++ b/tools/cortex-init.mjs
@@ -6,9 +6,15 @@
  * source-of-truth AGENTS.md plus tiny shims so every AI agent (Claude, Gemini,
  * Copilot, Cursor) reads the same project knowledge — and Claude-only dev-cycle skills.
  *
- * Run from inside a repo:
- *   node path/to/cortex-init.mjs
- *   npx cortex-init            (once published / via github)
+ * Run from inside a repo — any shell (bash, zsh, gitbash, PowerShell), any JS runtime:
+ *   node  path/to/cortex-init.mjs
+ *   bun   path/to/cortex-init.mjs
+ *   npx   github:marinvch/ai-os
+ *   bunx  github:marinvch/ai-os
+ *
+ * Interactive in a real terminal; non-interactive when answers are piped in or with --yes:
+ *   printf 'Name\nWhat it does\nKey rule\nall\n' | node path/to/cortex-init.mjs
+ *   node path/to/cortex-init.mjs --yes        (accept all detected defaults)
  *
  * Writes ONLY inside the current working directory. Backs up existing files to *.bak.
  */
@@ -25,6 +31,17 @@ const today = new Date().toISOString().slice(0, 10);
 const read = (p) => { try { return readFileSync(join(cwd, p), 'utf8'); } catch { return null; } };
 const readJson = (p) => { const t = read(p); if (!t) return null; try { return JSON.parse(t); } catch { return null; } };
 const has = (p) => existsSync(join(cwd, p));
+
+// Read all of (non-TTY) stdin once. Works identically under node and bun, and for input
+// piped from any shell. readline/promises drops piped input after the first answer, so we
+// don't use it for non-interactive runs.
+const readStdin = () => new Promise((resolve) => {
+  let data = '';
+  input.setEncoding('utf8');
+  input.on('data', (c) => { data += c; });
+  input.on('end', () => resolve(data));
+  input.on('error', () => resolve(data));
+});
 
 function writeFile(relPath, content) {
   const abs = join(cwd, relPath);
@@ -50,7 +67,8 @@ function detect() {
   else if (d('@angular/core')) framework = 'Angular';
   else if (d('express') || d('fastify') || d('koa')) framework = 'Node backend';
 
-  const pm = has('pnpm-lock.yaml') ? 'pnpm' : has('yarn.lock') ? 'yarn' : has('bun.lockb') ? 'bun' : 'npm';
+  const pm = has('pnpm-lock.yaml') ? 'pnpm' : has('yarn.lock') ? 'yarn'
+    : (has('bun.lockb') || has('bun.lock')) ? 'bun' : 'npm';
   const lang = has('tsconfig.json') || d('typescript') ? 'TypeScript' : 'JavaScript';
   const bundler = d('vite') ? 'Vite' : d('webpack') ? 'webpack' : pkg.scripts?.build?.includes('next') ? 'Next' : '';
   const styling = d('tailwindcss') ? 'Tailwind CSS' : d('styled-components') ? 'styled-components' : d('sass') ? 'Sass' : '';
@@ -86,14 +104,29 @@ async function main() {
   console.log(`    run: dev='${i.dev}' build='${i.build}' test='${i.test}' lint='${i.lint}'`);
   console.log(`    source dirs: ${i.dirs.join(', ') || '(none found)'}\n`);
 
-  const rl = createInterface({ input, output });
-  const ask = async (q, def) => ((await rl.question(`  ${q}${def ? ` [${def}]` : ''}: `)).trim() || def || '');
+  const yes = process.argv.slice(2).some((a) => a === '--yes' || a === '-y');
+  const interactive = Boolean(input.isTTY) && !yes;
 
-  const name = await ask('Project name', i.name);
-  const purpose = await ask('One line — what does this project do?', '');
-  const conventions = await ask('Any key rule the AI must follow? (optional)', '');
-  const agentsAns = (await ask('Generate shims for which agents? (claude,gemini,copilot,cursor or "all")', 'all')).toLowerCase();
-  rl.close();
+  let name, purpose, conventions, agentsAns;
+  if (interactive) {
+    const rl = createInterface({ input, output });
+    const ask = async (q, def) => ((await rl.question(`  ${q}${def ? ` [${def}]` : ''}: `)).trim() || def || '');
+    name = await ask('Project name', i.name);
+    purpose = await ask('One line — what does this project do?', '');
+    conventions = await ask('Any key rule the AI must follow? (optional)', '');
+    agentsAns = (await ask('Generate shims for which agents? (claude,gemini,copilot,cursor or "all")', 'all')).toLowerCase();
+    rl.close();
+  } else {
+    // Non-interactive: --yes accepts all defaults; otherwise read piped answers, one per
+    // line (name, purpose, key rule, agents). Blank or missing lines fall back to defaults.
+    const lines = (yes ? '' : await readStdin()).split(/\r?\n/);
+    const pick = (idx, def) => { const v = (lines[idx] ?? '').trim(); return v === '' ? (def ?? '') : v; };
+    name = pick(0, i.name);
+    purpose = pick(1, '');
+    conventions = pick(2, '');
+    agentsAns = pick(3, 'all').toLowerCase();
+    console.log(`  ${yes ? 'Non-interactive (--yes): using detected defaults.' : 'Non-interactive: reading answers from stdin.'}`);
+  }
 
   const want = (a) => agentsAns === 'all' || agentsAns.includes(a);
 


### PR DESCRIPTION
## Why
The **cortex-init test** workflow was failing on `master`. Root cause: the wizard drove `readline/promises` `question()` over stdin. With **non-TTY piped input** (the CI's `printf | node`, and any `echo | bunx ...`), the readline interface hits EOF after the first answer and the process exits before `main()` ever writes files — so the assert step saw every brain file missing.

## What changed
- **Input layer split** (`tools/cortex-init.mjs`): TTY → interactive prompts; non-TTY → read *all* stdin (one answer per line, blanks fall back to detected defaults). Added `--yes` for zero-input automation (never blocks).
- **Runtime/shell-agnostic**: works from bash, zsh, gitbash, PowerShell, under **node or bun**. Detects `bun.lock` (new bun lockfile) in addition to `bun.lockb`.
- **CI hardened**: smoke test now runs as a **matrix over `node` and `bun`**, plus a `--yes` assertion.
- **Docs**: README + tools/README show `npx`/`bunx`, any-shell usage, and non-interactive/`--yes` mode; fixed stale "root bin not wired" note and the wrong `cortex-init` global command name (it's `cortex`).

## Verification
- Local: piped input, `--yes`, and partial-input (blank → default) all write the full brain. ✅
- CI on this branch: **smoke (node): success**, **smoke (bun): success**. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)