### PR TITLE
feat(cortex-init): deeper scan, brownfield-safe, flags + vault bridge (closes #298-#302)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ layers you're maintaining are in [[vault-architecture]]: Capture, Knowledge, Con
 - `/install-project` (per repo) — stamp a *codebase brain* into a specific repo: scans the code and
   writes a project `AGENTS.md` + scoped `/plan-feature` and `/investigate-bug` skills. Isolated to
   that repo — company code never enters this personal vault.
+- `/scan-projects` (anytime) — opt-in, metadata-only bridge: list which repos on your machine have a
+  codebase brain and register the missing ones into `projects/` (name/path/URL/stack only — no code).
+  Pairs with `cortex-init --register-to-vault`. Keeps the privacy firewall intact.
 
 Each ritual is a plain `SKILL.md` (no engine, no Node). They live in `skills/` (committed,
 shareable); run `cp -r skills/* .claude/skills/` to expose them as Claude Code `/slash` commands.

--- a/README.md
+++ b/README.md
@@ -34,31 +34,42 @@ itself stays shareable and forkable.
 
 ## Give any repo a codebase brain (one-liner)
 
-Run this **inside any project repo** — it scans the code, asks a few questions, and writes an
-`AGENTS.md` + agent shims (Claude/Gemini/Copilot/Cursor) + dev-cycle skills into that repo.
-Works in any shell (bash, zsh, gitbash, PowerShell) and under either runtime:
+Run this **inside any project repo** — it detects the stack (package manager, framework, language),
+scripts, `tsconfig`, lint/CI, and route/source directories, then **scaffolds** an `AGENTS.md` +
+agent shims (Claude/Gemini/Copilot/Cursor) + dev-cycle skills into that repo. Works in any shell
+(bash, zsh, gitbash, PowerShell) and under either runtime:
 
 ```bash
 npx  github:marinvch/ai-os     # Node
 bunx github:marinvch/ai-os     # Bun
 ```
 
-Prefer non-interactive (CI, scripts)? Pipe the four answers — name, what-it-does, key rule,
-agents — or take all detected defaults with `--yes`:
+> It scaffolds from what it can detect, leaving `<…>` blanks for prose it can't infer. For a deep,
+> **AI-driven** pass that fills Architecture / Conventions / Gotchas from the actual code, open the
+> repo in Claude Code and run **`/install-project`**.
+
+Non-interactive (CI, scripts, agents)? Use flags, pipe the four answers, or take all defaults:
 
 ```bash
-printf 'MyApp\nWhat it does\nKey rule\nall\n' | npx github:marinvch/ai-os
 npx github:marinvch/ai-os --yes
+npx github:marinvch/ai-os --name=App --purpose="..." --agents=claude,gemini
+printf 'MyApp\nWhat it does\nKey rule\nall\n' | npx github:marinvch/ai-os
 ```
 
-Zero dependencies, nothing to install. It detects your package manager (npm/pnpm/yarn/bun)
-automatically. Review the generated `AGENTS.md`, then commit it so the whole team's agents share
-the same project knowledge. Source: `tools/cortex-init.mjs`.
+It's **brownfield-safe**: a curated `AGENTS.md`/`CLAUDE.md` is never clobbered (you get
+`AGENTS.generated.md` to diff instead), existing files back up to `*.bak`, and it warns if a
+generated file is gitignored. `--additive` refreshes only the skills. Optionally register the repo
+with your personal vault (metadata only, opt-in): `--register-to-vault ~/vault`. Run `--help` for
+all flags. Source: `tools/cortex-init.mjs`.
 
 ## Skills (rituals)
 
 Plain `SKILL.md` files in `skills/`. Say "run my onboard skill" in Cowork/Claude Code, or copy
 them into `.claude/skills/` to use as `/slash` commands (`cp -r skills/* .claude/skills/`).
+
+Includes `/scan-projects` — an opt-in, metadata-only bridge that lets the vault learn which repos
+on your machine have a codebase brain (no code ever leaves the repo). It pairs with
+`cortex-init --register-to-vault`.
 
 ## What changed from the old setup
 

--- a/skills/scan-projects/SKILL.md
+++ b/skills/scan-projects/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: scan-projects
+description: Sync the personal vault with the code repos on your machine — list which have a cortex "codebase brain", which are registered in projects/, and offer to register the rest (metadata only). Trigger on "scan my projects", "which repos have a brain", "sync my projects to the vault". Read-mostly; only writes opt-in metadata stubs.
+---
+
+# /scan-projects — bridge repos ↔ vault (metadata only)
+
+Keeps the vault aware of which projects exist **without absorbing any code**. Honors the privacy
+firewall: a project file holds name / path / URL / stack / date only — never code, secrets, or
+client data. This is the vault-side companion to the per-repo brain installed by `/install-project`
+(and by `cortex-init --register-to-vault`). See [[connections]].
+
+## Step 1 — Find the code root
+Ask for (or confirm) the folder that holds the user's repos (e.g. `D:\Projects`, `~/code`). If
+they've run this before, reuse the last root noted in `connections.md`.
+
+## Step 2 — Walk it (read-only)
+For each immediate subdirectory that is a git repo (`.git/` present), gather:
+- **name** — folder name, or `package.json` `"name"` if present.
+- **local path** and **remote URL** (`git -C <dir> remote get-url origin`).
+- **Has a brain?** — `AGENTS.md` or `.claude/skills/plan-feature/` exists.
+- **Registered?** — a file already exists at `projects/<slug>.md` in the vault.
+- **stack** — framework + language guessed from `package.json`.
+
+Never open source files. Folder listing + `package.json` + git metadata only.
+
+## Step 3 — Report the matrix
+```
+Repo                 Brain   Registered
+my-app               ✅      ✅
+client-api           ✅      ❌  ← can register
+old-script           ❌      ❌  ← no brain (run /install-project there)
+```
+End with a summary: `N repos · M with brains · K registered`.
+
+## Step 4 — Offer to sync (opt-in, metadata only)
+For repos that have a brain but are **not** registered, offer to write a stub to
+`projects/<slug>.md`. Ask before writing. Use exactly this shape (same as
+`cortex-init --register-to-vault`, so the two stay consistent):
+```markdown
+---
+type: project
+title: <name>
+status: active
+domain: business
+created: <today>
+tags: [project, codebase]
+---
+# <name>
+- **Local path:** `<path>`
+- **Repo:** <url>
+- **Stack:** <framework · language · pkg-mgr>
+- **Brain installed:** <date>
+
+## Outcome
+<one line>
+```
+No code. No secrets. No client data.
+
+## Step 5 — Flip the connection
+Once ≥1 project is registered, set the **Tasks / projects** row in `connections.md` to
+`Codebase brains` / `local files` / `✅ live` with today's date. Suggest re-running `/scan-projects`
+after installing new brains.
+
+## Rules
+- Read-only **except** the opt-in `projects/*.md` stubs and the one `connections.md` row.
+- Metadata only — the firewall stays intact; company code never enters the vault.
+- A repo with no brain → suggest running `/install-project` (or `npx github:marinvch/ai-os`) there.
+- One repo = one stub. Re-running refreshes the metadata (path/stack/date), never deletes notes.

--- a/tools/README.md
+++ b/tools/README.md
@@ -47,20 +47,52 @@ printf 'MyApp\nWhat it does\nKey rule\nall\n' | node tools/cortex-init.mjs
 node tools/cortex-init.mjs --yes
 ```
 
+## Flags
+
+```
+--name <s>               Project name (default: package.json name / folder)
+--purpose <s>            One line: what the project does
+--rule <s>               A key rule the AI must always follow
+--agents <list>          claude,gemini,copilot,cursor  or  all   (default: all)
+--yes, -y                Accept all detected defaults; no prompts, no stdin
+--additive               Refresh skills only; never touch AGENTS.md / shims
+--register-to-vault <p>  Append a metadata-only project stub to <vault>/projects/
+--help, -h               Show help
+```
+
 ## What it does
-1. Scans the repo (package.json, lockfile, configs, folders) to detect stack, scripts, conventions.
-2. Asks: project name, what it does, any key rule, which agents to support.
-3. Writes into the **current repo only** (backs up existing files to `*.bak`):
-   - `AGENTS.md` — the single source of truth (the project brain)
+1. **Detects** (it does not read your source): `package.json` deps + scripts, lockfile,
+   `tsconfig` (strict + first path alias), eslint/prettier/CI presence, the README's first line,
+   and route/source directories (`src/app`, `pages`, `src/routes`, `src/components`, …).
+2. **Asks** (or takes flags/stdin/`--yes`): name, what it does, a key rule, which agents.
+3. **Scaffolds** into the **current repo only** (existing files → `*.bak`):
+   - `AGENTS.md` — the source of truth, with real Stack/Run/Architecture/Conventions filled from
+     the scan and `<…>` blanks for prose it can't infer.
    - shims: `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursor/rules/project.mdc`
-   - `.claude/skills/plan-feature` + `investigate-bug`
-   - `docs/decisions.md`
-4. You review `AGENTS.md`, fix anything it guessed wrong, and commit.
+   - `.claude/skills/plan-feature` + `investigate-bug`, and `docs/decisions.md`
+4. You review `AGENTS.md`, fix anything it guessed, and commit.
+
+> This is a **fast scaffold**, not an AI scan. For deep prose (real Architecture/Conventions/Gotchas
+> read from the code), run the `/install-project` skill in Claude Code.
+
+## Safety on re-run / brownfield
+- **Never clobbers curated docs.** A hand-written `AGENTS.md` is preserved; the generated one is
+  written to `AGENTS.generated.md` to diff. A curated `CLAUDE.md` (anything but the `@AGENTS.md`
+  shim) is left untouched.
+- **Non-clobbering backups.** The first overwrite makes `file.bak`; later runs make
+  `file.bak.<timestamp>`, so the original is never lost.
+- **Gitignore-aware.** Warns if a generated file is ignored by the repo's `.gitignore` (so the team
+  doesn't silently miss it) and suggests adding `*.bak` to `.gitignore`.
+
+## Register with your personal vault (opt-in)
+`--register-to-vault <path>` writes a **metadata-only** stub to `<vault>/projects/<repo>.md`
+(name, local path, repo URL, one-line purpose, stack, install date) and flips the vault's
+`connections.md` "Tasks / projects" row to `local files`. No code, secrets, or client data — the
+firewall holds. The vault-side companion is the `/scan-projects` skill.
 
 ## After running
 - Open the repo in Claude Code → `/plan-feature` to start work (plan-before-implementing).
 - Commit `AGENTS.md` + shims so the whole team's agents share the brain.
-- Re-run anytime to refresh after big codebase changes (old files are backed up).
 
-> Self-contained: copy `cortex-init.mjs` to a work machine and it runs with just Node — no install,
-> no internet, no engine.
+> Self-contained: copy `cortex-init.mjs` to a work machine and it runs with just Node or Bun — no
+> install, no internet, no engine.

--- a/tools/cortex-init.mjs
+++ b/tools/cortex-init.mjs
@@ -46,9 +46,10 @@ const readStdin = () => new Promise((resolve) => {
 function writeFile(relPath, content) {
   const abs = join(cwd, relPath);
   mkdirSync(join(abs, '..'), { recursive: true });
-  if (existsSync(abs)) copyFileSync(abs, abs + '.bak'); // back up before overwrite
+  const backedUp = existsSync(abs);
+  if (backedUp) copyFileSync(abs, abs + '.bak'); // back up before overwrite
   writeFileSync(abs, content, 'utf8');
-  console.log('  ✓ ' + relPath + (existsSync(abs + '.bak') ? '  (old → .bak)' : ''));
+  console.log('  ✓ ' + relPath + (backedUp ? '  (old → .bak)' : ''));
 }
 
 // ── 1. scan the repo ───────────────────────────────────────────────────────────
@@ -85,7 +86,7 @@ function detect() {
   return {
     name: pkg.name || basename(cwd),
     framework, pm, lang, bundler, styling, testing,
-    install: s.install ? `${pm} install` : `${pm} install`,
+    install: `${pm} install`,
     dev: runCmd('dev') !== '—' ? runCmd('dev') : runCmd('start'),
     build: runCmd('build'), test: runCmd('test'), lint: runCmd('lint'),
     dirs,
@@ -128,6 +129,11 @@ async function main() {
     console.log(`  ${yes ? 'Non-interactive (--yes): using detected defaults.' : 'Non-interactive: reading answers from stdin.'}`);
   }
 
+  const KNOWN_AGENTS = ['claude', 'gemini', 'copilot', 'cursor'];
+  if (agentsAns !== 'all' && !KNOWN_AGENTS.some((a) => agentsAns.includes(a))) {
+    console.log(`  (couldn't match any agent in "${agentsAns}" — defaulting to all)`);
+    agentsAns = 'all';
+  }
   const want = (a) => agentsAns === 'all' || agentsAns.includes(a);
 
   // ── 3. write ─────────────────────────────────────────────────────────────────

--- a/tools/cortex-init.mjs
+++ b/tools/cortex-init.mjs
@@ -2,9 +2,10 @@
 /**
  * cortex-init — install a "codebase brain" into the current repo.
  *
- * Zero dependencies. Scans the repo, asks a few questions, then writes a single
- * source-of-truth AGENTS.md plus tiny shims so every AI agent (Claude, Gemini,
- * Copilot, Cursor) reads the same project knowledge — and Claude-only dev-cycle skills.
+ * Zero dependencies. Scans the repo (stack, scripts, tsconfig, lint/CI, route dirs), then writes a
+ * single source-of-truth AGENTS.md plus tiny shims so every AI agent (Claude, Gemini, Copilot,
+ * Cursor) reads the same project knowledge — and Claude-only dev-cycle skills. For a deep,
+ * AI-driven pass that fills prose from the actual code, run the /install-project skill in Claude.
  *
  * Run from inside a repo — any shell (bash, zsh, gitbash, PowerShell), any JS runtime:
  *   node  path/to/cortex-init.mjs
@@ -12,29 +13,41 @@
  *   npx   github:marinvch/ai-os
  *   bunx  github:marinvch/ai-os
  *
- * Interactive in a real terminal; non-interactive when answers are piped in or with --yes:
+ * Interactive in a real terminal; non-interactive via flags, piped stdin, or --yes:
  *   printf 'Name\nWhat it does\nKey rule\nall\n' | node path/to/cortex-init.mjs
- *   node path/to/cortex-init.mjs --yes        (accept all detected defaults)
+ *   node path/to/cortex-init.mjs --yes
+ *   node path/to/cortex-init.mjs --name=App --agents=claude,gemini --register-to-vault ~/vault
  *
- * Writes ONLY inside the current working directory. Backs up existing files to *.bak.
+ * Writes ONLY inside the current working directory (backs up existing files to *.bak), except the
+ * opt-in --register-to-vault, which writes one metadata-only stub into the vault. Run --help for all.
  */
 
 import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { readFileSync, existsSync, mkdirSync, writeFileSync, copyFileSync, readdirSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, dirname } from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 const cwd = process.cwd();
-const today = new Date().toISOString().slice(0, 10);
+const now = new Date();
+const today = now.toISOString().slice(0, 10);
+const stamp = now.toISOString().replace(/[:.]/g, '-'); // filesystem-safe, for non-clobbering backups
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 const read = (p) => { try { return readFileSync(join(cwd, p), 'utf8'); } catch { return null; } };
-const readJson = (p) => { const t = read(p); if (!t) return null; try { return JSON.parse(t); } catch { return null; } };
+const readAbs = (p) => { try { return readFileSync(p, 'utf8'); } catch { return null; } };
 const has = (p) => existsSync(join(cwd, p));
 
-// Read all of (non-TTY) stdin once. Works identically under node and bun, and for input
-// piped from any shell. readline/promises drops piped input after the first answer, so we
-// don't use it for non-interactive runs.
+function stripJsonComments(t) {
+  // tsconfig allows // and /* */ comments + trailing commas; strip them so JSON.parse works.
+  return t
+    .replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*|\/\*[\s\S]*?\*\//g, (m) => (m[0] === '"' ? m : ''))
+    .replace(/,(\s*[}\]])/g, '$1');
+}
+const readJson = (p) => { const t = read(p); if (!t) return null; try { return JSON.parse(stripJsonComments(t)); } catch { return null; } };
+
+// Read all of (non-TTY) stdin once. Works identically under node and bun, and for input piped from
+// any shell. readline/promises drops piped input after the first answer, so we don't use it here.
 const readStdin = () => new Promise((resolve) => {
   let data = '';
   input.setEncoding('utf8');
@@ -43,16 +56,121 @@ const readStdin = () => new Promise((resolve) => {
   input.on('error', () => resolve(data));
 });
 
-function writeFile(relPath, content) {
-  const abs = join(cwd, relPath);
-  mkdirSync(join(abs, '..'), { recursive: true });
-  const backedUp = existsSync(abs);
-  if (backedUp) copyFileSync(abs, abs + '.bak'); // back up before overwrite
+// Best-effort git (returns trimmed stdout, or null if git missing / not a repo).
+function git(args) {
+  try { return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); }
+  catch { return null; }
+}
+
+// Which of `paths` are gitignored here? [] = none, null = can't tell (no git / not a repo).
+function checkIgnored(paths) {
+  if (!paths.length) return [];
+  try {
+    const out = execFileSync('git', ['check-ignore', ...paths], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return out.split(/\r?\n/).filter(Boolean);
+  } catch (e) {
+    if (e && e.status === 1) return []; // git ran, nothing ignored
+    return null;                        // git unavailable / not a repo
+  }
+}
+
+const written = [];   // repo-relative paths actually written (for the gitignore check)
+let madeBackups = false;
+
+function writeAt(abs, content, label, track = true) {
+  mkdirSync(dirname(abs), { recursive: true });
+  let note = '';
+  if (existsSync(abs)) {
+    const bak = existsSync(abs + '.bak') ? `${abs}.bak.${stamp}` : `${abs}.bak`; // never clobber a prior .bak
+    copyFileSync(abs, bak);
+    madeBackups = true;
+    note = `  (old → ${basename(bak)})`;
+  }
   writeFileSync(abs, content, 'utf8');
-  console.log('  ✓ ' + relPath + (backedUp ? '  (old → .bak)' : ''));
+  const shown = label || abs;
+  if (track) written.push(shown);
+  console.log('  ✓ ' + shown + note);
+}
+const writeFile = (relPath, content) => writeAt(join(cwd, relPath), content, relPath);
+
+// AGENTS.md: if an existing file is curated (not ours), never clobber it — write *.generated.* to diff.
+function writeSmart(relPath, content, isOurs) {
+  const abs = join(cwd, relPath);
+  if (existsSync(abs)) {
+    if (!isOurs(readFileSync(abs, 'utf8'))) {
+      const alt = relPath.replace(/(\.[^.\\/]+)$/, '.generated$1');
+      writeFile(alt, content);
+      console.log(`  • kept your curated ${relPath}; wrote ${alt} for you to diff & merge.`);
+      return;
+    }
+  }
+  writeFile(relPath, content);
+}
+
+// Shims are tiny pointers: if an existing one is curated, leave it untouched (no .generated noise).
+function writeShim(relPath, content, isOurs) {
+  const abs = join(cwd, relPath);
+  if (existsSync(abs) && !isOurs(readFileSync(abs, 'utf8'))) {
+    console.log(`  • kept your curated ${relPath} — left it untouched.`);
+    return;
+  }
+  writeFile(relPath, content);
+}
+
+// ── arg parsing ────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const out = {};
+  const BOOL = new Set(['yes', 'additive', 'skip-instructions', 'non-interactive', 'help']);
+  for (let k = 0; k < argv.length; k++) {
+    const a = argv[k];
+    if (a === '-y') { out.yes = true; continue; }
+    if (a === '-h') { out.help = true; continue; }
+    if (!a.startsWith('--')) continue;
+    const body = a.slice(2);
+    const eq = body.indexOf('=');
+    if (eq !== -1) { out[body.slice(0, eq)] = body.slice(eq + 1); continue; }
+    if (BOOL.has(body)) { out[body] = true; continue; }
+    const next = argv[k + 1];
+    if (next === undefined || next.startsWith('-')) { out[body] = true; }
+    else { out[body] = next; k++; }
+  }
+  return out;
 }
 
 // ── 1. scan the repo ───────────────────────────────────────────────────────────
+const KNOWN_DIRS = {
+  src: 'Application source',
+  'src/app': 'App Router routes & layouts',
+  app: 'App Router routes & layouts',
+  'src/pages': 'Pages Router routes',
+  pages: 'Pages Router / routes',
+  'src/routes': 'SvelteKit routes',
+  'app/routes': 'Remix routes',
+  'src/components': 'Reusable UI components',
+  components: 'Reusable UI components',
+  'src/lib': 'Shared utilities & helpers',
+  lib: 'Shared utilities & helpers',
+  'src/hooks': 'React hooks',
+  'src/utils': 'Utility functions',
+  utils: 'Utility functions',
+  'src/server': 'Server-side code',
+  'src/api': 'API client / handlers',
+  api: 'API routes / handlers',
+  server: 'Server-side code',
+  prisma: 'Prisma schema & migrations',
+  public: 'Static assets served as-is',
+  styles: 'Global styles',
+  tests: 'Test suites',
+  test: 'Test suites',
+  __tests__: 'Test suites',
+  e2e: 'End-to-end tests',
+  docs: 'Documentation',
+  scripts: 'Dev / build scripts',
+  config: 'Configuration',
+  packages: 'Monorepo packages',
+  apps: 'Monorepo apps',
+};
+
 function detect() {
   const pkg = readJson('package.json') || {};
   const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
@@ -78,10 +196,42 @@ function detect() {
   const s = pkg.scripts || {};
   const runCmd = (name) => (s[name] ? `${pm} run ${name}` : '—');
 
-  // top-level source dirs (ignore noise)
-  const ignore = new Set(['node_modules', '.git', 'dist', 'build', '.next', '.cache', 'coverage', '.claude', '.github', '.cursor']);
-  let dirs = [];
-  try { dirs = readdirSync(cwd, { withFileTypes: true }).filter((e) => e.isDirectory() && !e.name.startsWith('.') && !ignore.has(e.name)).map((e) => e.name); } catch {}
+  // tsconfig signals: strict mode + first path alias
+  const ts = readJson('tsconfig.json') || {};
+  const co = ts.compilerOptions || {};
+  const tsStrict = co.strict === true ? true : co.strict === false ? false : null;
+  let alias = '';
+  if (co.paths && typeof co.paths === 'object') {
+    const key = Object.keys(co.paths)[0];
+    if (key) { const v = Array.isArray(co.paths[key]) ? co.paths[key][0] : co.paths[key]; alias = `${key} → ${v}`; }
+  }
+
+  // tooling configs
+  const eslint = ['.eslintrc', '.eslintrc.js', '.eslintrc.cjs', '.eslintrc.json', '.eslintrc.yml',
+    'eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs'].some(has) || Boolean(pkg.eslintConfig);
+  const prettier = ['.prettierrc', '.prettierrc.json', '.prettierrc.js', '.prettierrc.cjs',
+    'prettier.config.js', 'prettier.config.cjs'].some(has) || Boolean(pkg.prettier);
+  const ci = has('.github/workflows');
+
+  // README's first meaningful line → default "what is this"
+  const readme = read('README.md') || read('readme.md') || read('README') || '';
+  const readmeLine = readme.split(/\r?\n/).map((l) => l.trim())
+    .find((l) => l && !/^[#>!<|`-]/.test(l)) || '';
+
+  // architecture: real notes for known dirs (top-level + probed nested route/source dirs)
+  const ignore = new Set(['node_modules', '.git', 'dist', 'build', '.next', '.cache', 'coverage',
+    '.claude', '.github', '.cursor', '.vscode', '.idea']);
+  let topDirs = [];
+  try {
+    topDirs = readdirSync(cwd, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith('.') && !ignore.has(e.name)).map((e) => e.name);
+  } catch {}
+  const probes = ['src/app', 'app', 'src/pages', 'pages', 'src/routes', 'app/routes', 'src/components',
+    'components', 'src/lib', 'lib', 'src/hooks', 'src/utils', 'src/server', 'src/api', 'prisma'];
+  const archMap = new Map();
+  for (const dir of topDirs) archMap.set(dir + '/', KNOWN_DIRS[dir] || '<what lives here>');
+  for (const p of probes) if (has(p) && !archMap.has(p + '/')) archMap.set(p + '/', KNOWN_DIRS[p] || '<what lives here>');
+  const arch = [...archMap.entries()].map(([dir, note]) => ({ dir, note }));
 
   return {
     name: pkg.name || basename(cwd),
@@ -89,12 +239,16 @@ function detect() {
     install: `${pm} install`,
     dev: runCmd('dev') !== '—' ? runCmd('dev') : runCmd('start'),
     build: runCmd('build'), test: runCmd('test'), lint: runCmd('lint'),
-    dirs,
+    tsStrict, alias, eslint, prettier, ci, readmeLine, arch,
+    repoUrl: git(['remote', 'get-url', 'origin']) || '',
   };
 }
 
-// ── 2. ask ───────────────────────────────────────────────────────────────────
+// ── 2. run ─────────────────────────────────────────────────────────────────────
 async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) { printHelp(); return; }
+
   console.log('\n  🧠 cortex-init — give this repo a codebase brain');
   console.log('  repo: ' + cwd + '\n');
   const i = detect();
@@ -103,30 +257,38 @@ async function main() {
   console.log(`    name: ${i.name} · ${i.framework} · ${i.lang} · ${i.pm}` +
     (i.styling ? ` · ${i.styling}` : '') + (i.testing ? ` · ${i.testing}` : ''));
   console.log(`    run: dev='${i.dev}' build='${i.build}' test='${i.test}' lint='${i.lint}'`);
-  console.log(`    source dirs: ${i.dirs.join(', ') || '(none found)'}\n`);
+  const tooling = [i.tsStrict ? 'strict TS' : '', i.alias ? `alias ${i.alias}` : '',
+    i.eslint ? 'ESLint' : '', i.prettier ? 'Prettier' : '', i.ci ? 'CI' : ''].filter(Boolean);
+  if (tooling.length) console.log(`    tooling: ${tooling.join(' · ')}`);
+  console.log(`    dirs: ${i.arch.map((a) => a.dir).join(', ') || '(none found)'}\n`);
 
-  const yes = process.argv.slice(2).some((a) => a === '--yes' || a === '-y');
-  const interactive = Boolean(input.isTTY) && !yes;
+  const yes = Boolean(args.yes);
+  const additive = Boolean(args.additive || args['skip-instructions']);
+  const registerTo = typeof args['register-to-vault'] === 'string' ? args['register-to-vault'] : null;
+  const flag = (k) => (typeof args[k] === 'string' ? args[k] : undefined);
+  const haveAll = ['name', 'purpose', 'rule', 'agents'].every((k) => flag(k) !== undefined);
+  const interactive = Boolean(input.isTTY) && !yes && !haveAll;
 
   let name, purpose, conventions, agentsAns;
   if (interactive) {
     const rl = createInterface({ input, output });
     const ask = async (q, def) => ((await rl.question(`  ${q}${def ? ` [${def}]` : ''}: `)).trim() || def || '');
-    name = await ask('Project name', i.name);
-    purpose = await ask('One line — what does this project do?', '');
-    conventions = await ask('Any key rule the AI must follow? (optional)', '');
-    agentsAns = (await ask('Generate shims for which agents? (claude,gemini,copilot,cursor or "all")', 'all')).toLowerCase();
+    name = flag('name') ?? await ask('Project name', i.name);
+    purpose = flag('purpose') ?? await ask('One line — what does this project do?', i.readmeLine);
+    conventions = flag('rule') ?? await ask('Any key rule the AI must follow? (optional)', '');
+    agentsAns = (flag('agents') ?? await ask('Generate shims for which agents? (claude,gemini,copilot,cursor or "all")', 'all')).toLowerCase();
     rl.close();
   } else {
-    // Non-interactive: --yes accepts all defaults; otherwise read piped answers, one per
-    // line (name, purpose, key rule, agents). Blank or missing lines fall back to defaults.
-    const lines = (yes ? '' : await readStdin()).split(/\r?\n/);
+    // Non-interactive: flags win; otherwise read piped answers (one per line); blanks → defaults.
+    const lines = (yes || haveAll) ? [] : (await readStdin()).split(/\r?\n/);
     const pick = (idx, def) => { const v = (lines[idx] ?? '').trim(); return v === '' ? (def ?? '') : v; };
-    name = pick(0, i.name);
-    purpose = pick(1, '');
-    conventions = pick(2, '');
-    agentsAns = pick(3, 'all').toLowerCase();
-    console.log(`  ${yes ? 'Non-interactive (--yes): using detected defaults.' : 'Non-interactive: reading answers from stdin.'}`);
+    name = flag('name') ?? pick(0, i.name);
+    purpose = flag('purpose') ?? pick(1, i.readmeLine);
+    conventions = flag('rule') ?? pick(2, '');
+    agentsAns = (flag('agents') ?? pick(3, 'all')).toLowerCase();
+    console.log('  ' + (yes ? 'Non-interactive (--yes): using detected defaults.'
+      : haveAll ? 'Non-interactive: using provided --flags.'
+      : 'Non-interactive: reading answers from stdin.') + '\n');
   }
 
   const KNOWN_AGENTS = ['claude', 'gemini', 'copilot', 'cursor'];
@@ -137,26 +299,132 @@ async function main() {
   const want = (a) => agentsAns === 'all' || agentsAns.includes(a);
 
   // ── 3. write ─────────────────────────────────────────────────────────────────
-  console.log('\n  Writing the brain...');
+  console.log('  Writing the brain...');
 
-  writeFile('AGENTS.md', agentsMd({ ...i, name, purpose, conventions }));
-
-  if (want('claude')) writeFile('CLAUDE.md', '@AGENTS.md\n');
-  if (want('gemini')) writeFile('GEMINI.md', 'See AGENTS.md at the repo root for all project context, architecture, and conventions.\n');
-  if (want('copilot')) writeFile('.github/copilot-instructions.md', 'All project context and conventions live in `AGENTS.md` at the repo root. Read and follow it.\n');
-  if (want('cursor')) writeFile('.cursor/rules/project.mdc', '---\nalwaysApply: true\n---\nRead AGENTS.md at the repo root for architecture, conventions, and the development cycle.\n');
+  if (!additive) {
+    writeSmart('AGENTS.md', agentsMd({ ...i, name, purpose, conventions }), (c) => /Generated by cortex-init/.test(c));
+    const shimOurs = (c) => /AGENTS\.md/.test(c) && c.length < 320;
+    if (want('claude')) writeShim('CLAUDE.md', '@AGENTS.md\n', (c) => c.trim() === '@AGENTS.md');
+    if (want('gemini')) writeShim('GEMINI.md', GEMINI_SHIM, shimOurs);
+    if (want('copilot')) writeShim('.github/copilot-instructions.md', COPILOT_SHIM, shimOurs);
+    if (want('cursor')) writeShim('.cursor/rules/project.mdc', CURSOR_SHIM, shimOurs);
+  } else {
+    console.log('  (--additive: leaving AGENTS.md + agent shims untouched; refreshing skills only)');
+  }
 
   writeFile('.claude/skills/plan-feature/SKILL.md', planFeatureSkill());
   writeFile('.claude/skills/investigate-bug/SKILL.md', investigateBugSkill());
-  if (!has('docs/decisions.md')) writeFile('docs/decisions.md', `# Decision Log — ${name}\n\nAppend-only. Newest on top. Record why a technical call was made so it isn't re-litigated.\n`);
+  if (!has('docs/decisions.md')) {
+    writeFile('docs/decisions.md', `# Decision Log — ${name}\n\nAppend-only. Newest on top. Record why a technical call was made so it isn't re-litigated.\n`);
+  }
+
+  // ── 4. gitignore awareness (#302) ──────────────────────────────────────────────
+  const ignored = checkIgnored(written);
+  if (ignored && ignored.length) {
+    console.log("\n  ⚠ These generated files are gitignored here — teammates won't get them on clone:");
+    ignored.forEach((p) => console.log('     - ' + p));
+    console.log('     Remove the ignore rule, or commit them with `git add -f`.');
+  }
+  if (madeBackups) {
+    const bakIgnored = checkIgnored(['_cortex_sample_.bak']);
+    if (bakIgnored && bakIgnored.length === 0) {
+      console.log('\n  Tip: add `*.bak` to .gitignore so cortex-init backups are not committed.');
+    }
+  }
+
+  // ── 5. optional: register to the personal vault (#301, opt-in, metadata only) ───
+  if (registerTo) registerToVault(registerTo, { name, purpose, i });
 
   console.log('\n  ✅ Done. This repo now has a brain.');
-  console.log('  Next: open it in Claude Code and run /plan-feature when you start work.');
-  console.log('  Review AGENTS.md and fix anything I guessed wrong, then commit it.\n');
+  console.log('  That was a fast stack scan + scaffold. For a deep, AI-driven pass that fills');
+  console.log('  Architecture / Conventions / Gotchas from the actual code, open this repo in');
+  console.log('  Claude Code and run /install-project — then review AGENTS.md and commit it.\n');
 }
 
-// ── templates ──────────────────────────────────────────────────────────────────
+// ── vault bridge (#301) ──────────────────────────────────────────────────────────
+const slug = (s) => String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'project';
+
+function registerToVault(vaultPath, { name, purpose, i }) {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const root = vaultPath.replace(/^~(?=$|[/\\])/, home);
+  if (!existsSync(root)) {
+    console.log(`\n  ⚠ --register-to-vault: vault not found at ${root} (skipped).`);
+    return;
+  }
+  const stackBits = [i.framework, i.lang, i.pm, i.styling, i.testing].filter((x) => x && x !== 'Unknown');
+  const file = join(root, 'projects', `${slug(name)}.md`);
+  const body = `---
+type: project
+title: ${name}
+status: active
+domain: business
+created: ${today}
+tags: [project, codebase]
+---
+
+# ${name}
+
+> Metadata-only stub registered by cortex-init on ${today}. No code, secrets, or client data —
+> the codebase brain stays in the repo; the vault only learns this project exists.
+
+- **Local path:** \`${cwd}\`
+${i.repoUrl ? `- **Repo:** ${i.repoUrl}\n` : ''}- **Stack:** ${stackBits.join(' · ') || 'unknown'}
+- **Brain installed:** ${today}
+
+## Outcome
+${purpose || '<one sentence: what "done" looks like>'}
+
+## Next actions
+- [ ]
+`;
+  console.log('');
+  writeAt(file, body, `projects/${slug(name)}.md  (in vault)`, false);
+  flipConnectionsRow(root);
+}
+
+// Flip the "Tasks / projects" row in the vault's connections.md to `local files` once a project lands.
+function flipConnectionsRow(root) {
+  const cpath = join(root, 'connections.md');
+  const txt = readAbs(cpath);
+  if (!txt) return;
+  let changed = false;
+  const out = txt.split(/\r?\n/).map((ln) => {
+    if (!/Tasks\s*\/\s*projects/i.test(ln) || !ln.trim().startsWith('|')) return ln;
+    const cells = ln.split('|');
+    if (cells.length >= 7 && /not connected/i.test(cells[5])) {
+      cells[3] = ' Codebase brains ';
+      cells[4] = ' local files ';
+      cells[5] = ' ✅ live ';
+      cells[6] = ` ${today} `;
+      changed = true;
+      return cells.join('|');
+    }
+    return ln;
+  });
+  if (changed) writeAt(cpath, out.join('\n'), 'connections.md  (in vault)', false);
+}
+
+// ── templates ────────────────────────────────────────────────────────────────────
+const GEMINI_SHIM = 'See AGENTS.md at the repo root for all project context, architecture, and conventions.\n';
+const COPILOT_SHIM = 'All project context and conventions live in `AGENTS.md` at the repo root. Read and follow it.\n';
+const CURSOR_SHIM = '---\nalwaysApply: true\n---\nRead AGENTS.md at the repo root for architecture, conventions, and the development cycle.\n';
+
 function agentsMd(x) {
+  const archLines = x.arch.length
+    ? x.arch.map((a) => `- \`${a.dir}\` — ${a.note}`).join('\n')
+    : '- <map the important folders here>';
+
+  const conv = ['- Standard to hold: clear, maintainable, scalable code.'];
+  if (x.conventions) conv.push(`- ${x.conventions}`);
+  if (x.tsStrict) conv.push('- Strict TypeScript (`strict: true` in tsconfig) — keep it type-safe.');
+  if (x.alias) conv.push(`- Path alias: \`${x.alias}\` — prefer it over deep relative imports.`);
+  if (x.eslint) conv.push(`- Lint with ESLint${x.lint !== '—' ? ` (\`${x.lint}\`)` : ''} before committing.`);
+  if (x.prettier) conv.push("- Format with Prettier; don't hand-format.");
+  conv.push('- <add naming / component / import conventions as you confirm them in the code>');
+
+  const stackExtra = [x.bundler ? `Bundler: ${x.bundler}` : '', x.styling ? `Styling: ${x.styling}` : '',
+    x.testing ? `Testing: ${x.testing}` : ''].filter(Boolean);
+
   return `# ${x.name} — Project Brain (codebase-scoped)
 
 > AI instructions for THIS repo. Single source of truth — every agent reads it via its own shim.
@@ -166,17 +434,16 @@ function agentsMd(x) {
 ${x.purpose || '<one line: what this project does and who uses it>'}
 
 ## Stack & tooling
-- Framework: ${x.framework} · Language: ${x.lang} · Package manager: ${x.pm}${x.bundler ? ` · Bundler: ${x.bundler}` : ''}
-${x.styling ? `- Styling: ${x.styling}\n` : ''}${x.testing ? `- Testing: ${x.testing}\n` : ''}
+- Framework: ${x.framework} · Language: ${x.lang} · Package manager: ${x.pm}
+${stackExtra.length ? `- ${stackExtra.join(' · ')}\n` : ''}${x.ci ? '- CI: GitHub Actions (`.github/workflows`)\n' : ''}
 ## Run it
 - install: \`${x.install}\` · dev: \`${x.dev}\` · build: \`${x.build}\` · test: \`${x.test}\` · lint: \`${x.lint}\`
 
 ## Architecture (key directories)
-${x.dirs.length ? x.dirs.map((d) => `- \`${d}/\` — <what lives here>`).join('\n') : '- <map the important folders here>'}
+${archLines}
 
 ## Conventions
-- Standard to hold: clear, maintainable, scalable code.
-${x.conventions ? `- ${x.conventions}\n` : ''}- <naming, component patterns, import rules — fill from the codebase>
+${conv.join('\n')}
 
 ## Development cycle (the hard rule)
 1. **Plan before implementing.** No code until there's a written plan (use \`/plan-feature\`).
@@ -185,7 +452,7 @@ ${x.conventions ? `- ${x.conventions}\n` : ''}- <naming, component patterns, imp
 4. Self-review against the conventions above before opening a PR.
 
 ## Gotchas / tribal knowledge
-- <quirks, flaky areas, build traps — grows over time>
+- <quirks, flaky areas, build traps — grows over time; or run /install-project to seed from the code>
 
 ## Glossary
 - <domain terms specific to this codebase>
@@ -219,6 +486,30 @@ description: Systematically investigate a bug in THIS repo. Use when given a bug
 3. Confirm the root cause with evidence (code refs, a failing test if possible).
 4. Propose the smallest correct fix + how to verify it. Plan before editing.
 `;
+}
+
+function printHelp() {
+  console.log(`
+  cortex-init — install a codebase brain into the current repo.
+
+  Usage:
+    cortex-init [options]
+    npx github:marinvch/ai-os [options]
+    printf 'name\\npurpose\\nrule\\nagents\\n' | cortex-init   # non-interactive
+
+  Options:
+    --name <s>               Project name (default: package.json name / folder)
+    --purpose <s>            One line: what the project does
+    --rule <s>               A key rule the AI must always follow
+    --agents <list>          claude,gemini,copilot,cursor  or  all   (default: all)
+    --yes, -y                Accept all detected defaults; no prompts, no stdin
+    --additive               Refresh skills only; never touch AGENTS.md / shims
+    --register-to-vault <p>  Append a metadata-only project stub to <vault>/projects/
+    --help, -h               Show this help
+
+  Writes only inside the current repo (existing files backed up to *.bak), except
+  --register-to-vault, which writes one metadata-only stub into the vault.
+`);
 }
 
 main().catch((e) => { console.error('\n  cortex-init failed:', e.message); process.exit(1); });


### PR DESCRIPTION
Resolves all five open cortex-init issues. Builds on the merged non-TTY fix (#297).

## #298 — flags / automation
Real arg parser: `--name --purpose --rule --agents --yes/-y --additive --register-to-vault --help`. (The non-TTY hang itself was fixed in #297; this completes the flag surface agents/CI need.)

## #299 — real scan, honest docs
`detect()` now reads `tsconfig` (strict + first path alias), eslint/prettier/CI presence, the README's first line, and route/source dirs (`src/app`, `pages`, `src/routes`, `src/components`, …). `AGENTS.md` gets **real** Architecture/Conventions instead of placeholders. README + tools/README no longer claim a full code scan and point to `/install-project` for the deep AI pass.

## #300 — brownfield-safe
A curated `AGENTS.md` is never clobbered → written to `AGENTS.generated.md` to diff. A curated `CLAUDE.md`/shim is left untouched. `--additive` refreshes only the skills.

## #302 — backups + gitignore
Non-clobbering backups (`file.bak`, then `file.bak.<timestamp>`). Warns when a generated file is gitignored; suggests adding `*.bak`.

## #301 — opt-in vault bridge
`--register-to-vault <path>` writes a **metadata-only** `projects/<repo>.md` stub (name/path/URL/stack/date — no code/secrets) and flips `connections.md` "Tasks / projects" to `local files`. New **`/scan-projects`** skill is the vault-side companion. Privacy firewall preserved.

## Verification
Deep scan, all flags, brownfield preserve, idempotent refresh + backups, `--additive`, gitignore warning, vault register + connections flip, and the CI piped/`--yes` scenarios — all pass locally under node. CI runs the smoke matrix under **node + bun**.

Closes #298
Closes #299
Closes #300
Closes #301
Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
